### PR TITLE
fix: stop click event propagation on MenuItem

### DIFF
--- a/src/components/dropdown-menu/MenuItems.tsx
+++ b/src/components/dropdown-menu/MenuItems.tsx
@@ -126,7 +126,8 @@ function Item<T>(props: ItemProps<T>) {
     <Menu.Item disabled={option.disabled}>
       {({ active }) => (
         <ItemDiv
-          onClick={() => {
+          onClick={(e) => {
+            e.stopPropagation();
             onSelect(option);
           }}
           active={active}

--- a/src/components/dropdown-menu/MenuItems.tsx
+++ b/src/components/dropdown-menu/MenuItems.tsx
@@ -126,8 +126,8 @@ function Item<T>(props: ItemProps<T>) {
     <Menu.Item disabled={option.disabled}>
       {({ active }) => (
         <ItemDiv
-          onClick={(e) => {
-            e.stopPropagation();
+          onClick={(event) => {
+            event.stopPropagation();
             onSelect(option);
           }}
           active={active}


### PR DESCRIPTION
closes: https://github.com/zakodium-oss/react-science/issues/445