### PR TITLE
fix: parse decimal size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "react-science",
-      "version": "0.19.1",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.10.5",

--- a/src/components/split-pane/SplitPane.tsx
+++ b/src/components/split-pane/SplitPane.tsx
@@ -215,11 +215,11 @@ function SplitSide(props: SplitSideProps) {
 }
 
 function parseSize(initialSize: string): [number, SplitPaneType] {
-  const [, value, type] = /(?<value>^\d+)(?<type>.+)$/.exec(
-    initialSize,
-  ) as unknown as [string, string, SplitPaneType];
+  const value = Number.parseFloat(initialSize);
+  // remove numbers and dots from the string
+  const type = initialSize.replace(/[\d .]/g, '') as SplitPaneType;
 
-  return [Number(value), type];
+  return [value, type];
 }
 
 const flexBase = 100;


### PR DESCRIPTION
closes : https://github.com/zakodium-oss/react-science/issues/450

the problem was in `parseSize` function

I had two solution
- Update the old regex :
```js
const [, value, type] = /(?<value>^\d+\.?\d+)(?<type>.+)$/.exec(
 initialSize,
) as unknown as [string, string, SplitPaneType];
```
 
- Get float from the parsed string then extract type by deleting the rest
```js
const value = Number.parseFloat(initialSize);
const type = initialSize.replace(/[\d .]/g, '') as SplitPaneType;
```

I prefer the second one, which is implemented in this PR