### PR TITLE
fix: modal should not take space in the layout if no nodes inside it

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -17,7 +17,6 @@ export interface ModalProps {
 }
 
 const DialogRoot = styled.dialog`
-  display: flex;
   position: fixed;
   background-color: transparent;
 


### PR DESCRIPTION
-  https://github.com/zakodium-oss/react-science/issues/459