### PR TITLE
fix(tabs): ensure consistant behavior between horizontal and vertical

### DIFF
--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -152,7 +152,7 @@ function TabsHorizontal<T extends string = string>(
   const item = useTabsContext();
   return (
     <div
-      style={{ display: 'flex', flexDirection: 'column', overflowX: 'hidden' }}
+      style={{ display: 'flex', flexDirection: 'column', overflowX: 'hidden', flex: '1 1 0%', height: '100%' }}
     >
       <div
         style={{

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -152,7 +152,12 @@ function TabsHorizontal<T extends string = string>(
   const item = useTabsContext();
   return (
     <div
-      style={{ display: 'flex', flexDirection: 'column', overflowX: 'hidden', height: '100%' }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflowX: 'hidden',
+        height: '100%',
+      }}
     >
       <div
         style={{

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -152,7 +152,7 @@ function TabsHorizontal<T extends string = string>(
   const item = useTabsContext();
   return (
     <div
-      style={{ display: 'flex', flexDirection: 'column', overflowX: 'hidden', flex: '1 1 0%', height: '100%' }}
+      style={{ display: 'flex', flexDirection: 'column', overflowX: 'hidden', height: '100%' }}
     >
       <div
         style={{

--- a/stories/components/tabs.stories.tsx
+++ b/stories/components/tabs.stories.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, useState} from 'react';
+import { ReactNode, useState } from 'react';
 
 import { Tabs, TabItem } from '../../src/components/index';
 

--- a/stories/components/tabs.stories.tsx
+++ b/stories/components/tabs.stories.tsx
@@ -30,6 +30,36 @@ export function Horizontal() {
   );
 }
 
+function FullHeightContent({ children }: { children: ReactNode}) {
+  return (
+    <div style={{backgroundColor: 'rgb(251, 207, 232)', height: '100%'}}>{children}</div>
+  )
+}
+
+export function AllowHorizontalChildToTakeFullHeight() {
+  const items: Array<TabItem> = [
+    { id: '1h', title: '1H', content: <FullHeightContent>Hello, World! [a]</FullHeightContent> },
+    { id: '13c', title: '13C', content: <FullHeightContent>Hello, World! [b]</FullHeightContent> },
+    { id: '1h,1h', title: '1H,1H', content: <FullHeightContent>Hello, World! [c]</FullHeightContent> },
+    { id: '1h,13c', title: '1H,13C', content: <FullHeightContent>Hello, World! [d]</FullHeightContent> },
+  ];
+
+  const [state, setState] = useState(items[1].id);
+
+  function handleClick(id: string) {
+    setState(id);
+  }
+
+  return (
+    <Tabs
+      orientation="horizontal"
+      items={items}
+      opened={state}
+      onClick={handleClick}
+    />
+  );
+}
+
 export function ManyTabs({
   orientation,
 }: {

--- a/stories/components/tabs.stories.tsx
+++ b/stories/components/tabs.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import {ReactNode, useState} from 'react';
 
 import { Tabs, TabItem } from '../../src/components/index';
 
@@ -30,18 +30,36 @@ export function Horizontal() {
   );
 }
 
-function FullHeightContent({ children }: { children: ReactNode}) {
+function FullHeightContent({ children }: { children: ReactNode }) {
   return (
-    <div style={{backgroundColor: 'rgb(251, 207, 232)', height: '100%'}}>{children}</div>
-  )
+    <div style={{ backgroundColor: 'rgb(251, 207, 232)', height: '100%' }}>
+      {children}
+    </div>
+  );
 }
 
 export function AllowHorizontalChildToTakeFullHeight() {
   const items: Array<TabItem> = [
-    { id: '1h', title: '1H', content: <FullHeightContent>Hello, World! [a]</FullHeightContent> },
-    { id: '13c', title: '13C', content: <FullHeightContent>Hello, World! [b]</FullHeightContent> },
-    { id: '1h,1h', title: '1H,1H', content: <FullHeightContent>Hello, World! [c]</FullHeightContent> },
-    { id: '1h,13c', title: '1H,13C', content: <FullHeightContent>Hello, World! [d]</FullHeightContent> },
+    {
+      id: '1h',
+      title: '1H',
+      content: <FullHeightContent>Hello, World! [a]</FullHeightContent>,
+    },
+    {
+      id: '13c',
+      title: '13C',
+      content: <FullHeightContent>Hello, World! [b]</FullHeightContent>,
+    },
+    {
+      id: '1h,1h',
+      title: '1H,1H',
+      content: <FullHeightContent>Hello, World! [c]</FullHeightContent>,
+    },
+    {
+      id: '1h,13c',
+      title: '1H,13C',
+      content: <FullHeightContent>Hello, World! [d]</FullHeightContent>,
+    },
   ];
 
   const [state, setState] = useState(items[1].id);


### PR DESCRIPTION
Without the change, vertical tabs allow their child to work in 100% of the width:
![image](https://github.com/zakodium-oss/react-science/assets/2575182/b42162c5-30f7-425b-bbe1-4133690e0ff5)

but horizontal tabs are limited to their own height:
![image](https://github.com/zakodium-oss/react-science/assets/2575182/0dfc6777-c908-4b50-9da6-bcef119cfaa5)

