### PR TITLE
fix: pass down style props on modals

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import type { ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 
 import { Portal } from '../root-layout/Portal';
 
@@ -98,14 +98,50 @@ export function Modal(props: ModalProps) {
   );
 }
 
-Modal.Header = function ModalHeader(props: { children: ReactNode }) {
-  return <ModalHeaderStyled>{props.children}</ModalHeaderStyled>;
+Modal.Header = function ModalHeader({
+  children,
+  style,
+  className,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+  className?: string;
+}) {
+  return (
+    <ModalHeaderStyled style={style} className={className}>
+      {children}
+    </ModalHeaderStyled>
+  );
 };
 
-Modal.Body = function ModalBody(props: { children: ReactNode }) {
-  return <ModalBodyStyled>{props.children}</ModalBodyStyled>;
+Modal.Body = function ModalBody({
+  children,
+  style,
+  className,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+  className?: string;
+}) {
+  return (
+    <ModalBodyStyled style={style} className={className}>
+      {children}
+    </ModalBodyStyled>
+  );
 };
 
-Modal.Footer = function ModalFooter(props: { children: ReactNode }) {
-  return <ModalFooterStyled>{props.children}</ModalFooterStyled>;
+Modal.Footer = function ModalFooter({
+  children,
+  style,
+  className,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+  className?: string;
+}) {
+  return (
+    <ModalFooterStyled style={style} className={className}>
+      {children}
+    </ModalFooterStyled>
+  );
 };

--- a/stories/components/modal.stories.tsx
+++ b/stories/components/modal.stories.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { useState } from 'react';
 import {
   FaMeteor,
@@ -274,6 +275,93 @@ WithComplexContents.args = {
 };
 
 WithComplexContents.argTypes = actions;
+
+export function PassDownStyle(props: {
+  onSave: () => void;
+  onRequestClose: () => void;
+}) {
+  const [isOpen, open, close] = useOnOff();
+
+  const { onSave, onRequestClose, ...otherProps } = props;
+
+  const BlueFooter = styled(Modal.Footer)`
+    background-color: blue;
+  `;
+
+  return (
+    <>
+      <DemoPage openModal={open} />
+      <Modal
+        isOpen={isOpen}
+        onRequestClose={() => {
+          onRequestClose();
+          close();
+        }}
+        {...otherProps}
+      >
+        <Modal.Header style={{ backgroundColor: 'red' }}>
+          Hello, World!
+        </Modal.Header>
+        <Modal.Body>
+          <div
+            style={{
+              display: 'flex',
+              flex: '1 1 0%',
+              flexDirection: 'row',
+            }}
+          >
+            <Toolbar orientation="vertical">
+              <Toolbar.Item title="react">
+                <FaReact />
+              </Toolbar.Item>
+              <Toolbar.Item title="npm">
+                <FaNpm />
+              </Toolbar.Item>
+              <Toolbar.Item title="nodejs">
+                <FaNodeJs />
+              </Toolbar.Item>
+            </Toolbar>
+            <p style={{ paddingLeft: 10 }}>
+              Lorem ipsum dolor sit, amet consectetur adipisicing elit. Modi
+              accusamus voluptas odit minima amet obcaecati eveniet voluptatibus
+              assumenda esse animi id atque natus ipsa sunt iure illo,
+              exercitationem voluptates non.
+            </p>
+          </div>
+        </Modal.Body>
+        <BlueFooter>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row-reverse',
+            }}
+          >
+            <Button
+              onClick={onSave}
+              backgroundColor={{
+                basic: 'hsla(243deg, 75%, 58%, 1)',
+                hover: 'hsla(245deg, 58%, 50%, 1)',
+              }}
+              color={{ basic: 'white' }}
+            >
+              Save
+            </Button>
+          </div>
+        </BlueFooter>
+      </Modal>
+    </>
+  );
+}
+
+PassDownStyle.args = {
+  hasCloseButton: true,
+  height: 400,
+  maxWidth: 600,
+  requestCloseOnBackdrop: true,
+  requestCloseOnEsc: true,
+};
+
+PassDownStyle.argTypes = actions;
 
 function DemoPage(props: { openModal: () => void }) {
   return (


### PR DESCRIPTION
The change allow user to decorate over already made components like `Modal.Body` or `Modal.Header`.

A workaround can be to re-encapsulate the `Modal.Header` in another `div` styled with what we want, but if we are working with heights it is not alway sufficient.