### PR TITLE
fix: modal generate a new portal context

### DIFF
--- a/src/components/hooks/useOnClickOutside.ts
+++ b/src/components/hooks/useOnClickOutside.ts
@@ -19,6 +19,8 @@ export function useOnClickOutside<T extends Node = Node>(
       handler(event);
     };
 
+    if (shadowElement === null) return;
+
     shadowElement.addEventListener('mousedown', listener);
     shadowElement.addEventListener('touchstart', listener);
 

--- a/src/components/modal/useDialog.ts
+++ b/src/components/modal/useDialog.ts
@@ -42,14 +42,27 @@ export function useDialog({
 
   const onClick = useCallback<MouseEventHandler<HTMLDialogElement>>(
     (event) => {
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+
+      // Ref: https://stackoverflow.com/questions/25864259/how-to-close-the-new-html-dialog-tag-by-clicking-on-its-backdrop
+      const rect = dialog.getBoundingClientRect();
+      const isInDialog =
+        rect.top <= event.clientY &&
+        event.clientY <= rect.top + rect.height &&
+        rect.left <= event.clientX &&
+        event.clientX <= rect.left + rect.width;
+
       event.stopPropagation();
       // Since the dialog has no size of itself, this condition is only
       // `true` when we click on the backdrop.
-      if (event.target === event.currentTarget && requestCloseOnBackdrop) {
+      if (!isInDialog && requestCloseOnBackdrop) {
         onRequestClose?.();
       }
     },
-    [requestCloseOnBackdrop, onRequestClose],
+    [dialogRef, requestCloseOnBackdrop, onRequestClose],
   );
 
   return { onClick, onCancel };

--- a/src/components/modal/useDialog.ts
+++ b/src/components/modal/useDialog.ts
@@ -1,18 +1,20 @@
 import {
   MouseEventHandler,
   ReactEventHandler,
+  RefObject,
   useCallback,
   useEffect,
-  useRef,
 } from 'react';
 import { useKbsDisableGlobal } from 'react-kbs';
 
 export function useDialog({
+  dialogRef,
   isOpen,
   requestCloseOnEsc,
   requestCloseOnBackdrop,
   onRequestClose,
 }: {
+  dialogRef: RefObject<HTMLDialogElement>;
   isOpen: boolean;
   requestCloseOnEsc: boolean;
   requestCloseOnBackdrop: boolean;
@@ -20,15 +22,13 @@ export function useDialog({
 }) {
   useKbsDisableGlobal(isOpen);
 
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   useEffect(() => {
     const dialog = dialogRef.current;
     if (dialog && isOpen) {
       dialog.showModal();
       return () => dialog.close();
     }
-  }, [isOpen]);
+  }, [dialogRef, isOpen]);
 
   const onCancel = useCallback<ReactEventHandler<HTMLDialogElement>>(
     (event) => {
@@ -52,5 +52,5 @@ export function useDialog({
     [requestCloseOnBackdrop, onRequestClose],
   );
 
-  return { ref: dialogRef, onClick, onCancel };
+  return { onClick, onCancel };
 }

--- a/src/components/root-layout/Portal.tsx
+++ b/src/components/root-layout/Portal.tsx
@@ -9,5 +9,8 @@ interface PortalProps {
 
 export function Portal(props: PortalProps) {
   const element = useRootLayoutContext();
+  if (element === null) {
+    return null;
+  }
   return createPortal(props.children, element);
 }

--- a/src/components/root-layout/RootLayoutContext.tsx
+++ b/src/components/root-layout/RootLayoutContext.tsx
@@ -1,13 +1,14 @@
 import { createContext, ReactNode, useContext } from 'react';
 
-const rootLayoutContext = createContext<HTMLElement | null>(null);
+const defaultPortalContext =
+  typeof document === 'undefined' ? null : document.body;
+
+const rootLayoutContext = createContext<HTMLElement | null>(
+  defaultPortalContext,
+);
 
 export function useRootLayoutContext() {
   const context = useContext(rootLayoutContext);
-  if (!context) {
-    throw new Error('RootLayoutContext was not found');
-  }
-
   return context;
 }
 

--- a/stories/components/select.stories.tsx
+++ b/stories/components/select.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Button } from '../../src/components';
+import { Button, Modal, useOnOff } from '../../src/components';
 import { Select } from '../../src/components/forms/Select';
 
 export default {
@@ -298,5 +298,46 @@ export function ResetButton() {
       <p>Value outside component is {value}.</p>
       <Button onClick={() => setValue(undefined)}>Reset</Button>
     </div>
+  );
+}
+
+export function InModal() {
+  const [isOpen, open, close] = useOnOff();
+  const [value, setValue] = useState<string | undefined>(undefined);
+  return (
+    <>
+      <Button
+        onClick={open}
+        backgroundColor={{
+          basic: 'hsla(243deg, 75%, 58%, 1)',
+          hover: 'hsla(245deg, 58%, 50%, 1)',
+        }}
+        color={{ basic: 'white' }}
+      >
+        Open
+      </Button>
+      <Modal
+        isOpen={isOpen}
+        onRequestClose={() => {
+          close();
+        }}
+      >
+        <Modal.Header>Select a fruit</Modal.Header>
+        <Modal.Body>
+          <p>Hello, world!</p>
+          <Select
+            value={value}
+            onSelect={setValue}
+            options={[
+              [
+                { label: 'Apple', value: 'apple' },
+                { label: 'Banana', value: 'banana' },
+                { label: 'Orange', value: 'orange' },
+              ],
+            ]}
+          />
+        </Modal.Body>
+      </Modal>
+    </>
   );
 }


### PR DESCRIPTION
Modal now create a root layout to ensure Select components opens in front of the modal instead of behind.