### PR TITLE
fix: set min-width or min-height on split-pane

### DIFF
--- a/src/components/split-pane/SplitPane.tsx
+++ b/src/components/split-pane/SplitPane.tsx
@@ -175,6 +175,7 @@ export function SplitPane(props: SplitPaneProps) {
         display: 'flex',
         height: '100%',
         width: '100%',
+        [direction === 'horizontal' ? 'minWidth' : 'minHeight']: 0,
         flexDirection: direction === 'horizontal' ? 'row' : 'column',
       }}
     >


### PR DESCRIPTION
Sometime the second child of SplitPane overflows the SplitPane:
![hofUfEBO51](https://github.com/zakodium-oss/react-science/assets/2575182/5ae29cfd-01ea-4170-baf0-88babc5a10e2)

It doesn't happen with the proposed change.
![image](https://github.com/zakodium-oss/react-science/assets/2575182/7d10d1f1-b4b9-4750-9139-ac4234aac8e6)
