### PR TITLE
fix: allow to pass tag type for dropdown menu button

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -1,6 +1,13 @@
 import { Menu } from '@headlessui/react';
 import type { Placement } from '@popperjs/core';
-import { ReactNode, useRef, ElementType, ComponentProps } from 'react';
+import React, {
+  ReactNode,
+  useRef,
+  ElementType,
+  ComponentProps,
+  JSXElementConstructor,
+  JSX,
+} from 'react';
 
 import { useModifiedPopper } from '../hooks/useModifiedPopper';
 import { useOnClickOutside } from '../hooks/useOnClickOutside';
@@ -24,12 +31,13 @@ type ElementProps<E = unknown> = E extends ElementType
   ? ComponentProps<E>
   : never;
 
-interface DropdownMenuClickProps<T> extends DropdownMenuBaseProps<T> {
+interface DropdownMenuClickProps<T, E> extends DropdownMenuBaseProps<T> {
   /**
    * Node to be inside the Button
    */
   children: ReactNode;
   trigger: 'click';
+  as?: E;
 }
 
 interface DropdownMenuContextProps<T, E> extends DropdownMenuBaseProps<T> {
@@ -40,7 +48,7 @@ interface DropdownMenuContextProps<T, E> extends DropdownMenuBaseProps<T> {
 
 export type DropdownMenuProps<T, E> =
   | DropdownMenuContextProps<T, E>
-  | DropdownMenuClickProps<T>;
+  | DropdownMenuClickProps<T, E>;
 
 export function DropdownMenu<T = unknown, E extends ElementType = 'div'>(
   props: DropdownMenuProps<T, E> &
@@ -52,7 +60,9 @@ export function DropdownMenu<T = unknown, E extends ElementType = 'div'>(
     return <DropdownContextMenu<T, E> {...props} />;
   }
   return (
-    <DropdownClickMenu {...otherProps}>{props.children}</DropdownClickMenu>
+    <DropdownClickMenu<T, E> {...otherProps}>
+      {props.children}
+    </DropdownClickMenu>
   );
 }
 
@@ -119,10 +129,17 @@ function DropdownContextMenu<T, E extends ElementType = 'div'>(
   );
 }
 
-function DropdownClickMenu<T, E>(
-  props: Omit<DropdownMenuProps<T, E>, 'trigger'> & { children: ReactNode },
+function DropdownClickMenu<T, E extends ElementType = 'div'>(
+  props: Omit<DropdownMenuProps<T, E>, 'trigger'> & {
+    children: ReactNode;
+  },
 ) {
-  const { placement = 'bottom-start', onSelect, ...otherProps } = props;
+  const {
+    placement = 'bottom-start',
+    onSelect,
+    as = 'button',
+    ...otherProps
+  } = props;
 
   const [isOpened, , closeItems, toggle] = useOnOff(false);
 
@@ -134,7 +151,11 @@ function DropdownClickMenu<T, E>(
 
   return (
     <Menu>
-      <Menu.Button ref={setReferenceElement} onClick={toggle}>
+      <Menu.Button
+        ref={setReferenceElement}
+        onClick={toggle}
+        as={as as keyof JSX.IntrinsicElements | JSXElementConstructor<any>}
+      >
         {props.children}
       </Menu.Button>
       {isOpened && (

--- a/stories/components/dropdown.stories.tsx
+++ b/stories/components/dropdown.stories.tsx
@@ -11,6 +11,7 @@ import {
   FaAd,
   FaAddressCard,
   FaAdjust,
+  FaFilter,
 } from 'react-icons/fa';
 
 import {
@@ -20,6 +21,7 @@ import {
 import {
   DropdownMenu,
   Table,
+  Toolbar,
   ValueRenderers,
 } from '../../src/components/index';
 import data from '../data/table.json';
@@ -355,5 +357,22 @@ export function TableWithContextMenu() {
         ))}
       </tbody>
     </TableWithContext>
+  );
+}
+
+export function DropdownMenuCustomAsTag() {
+  return (
+    <Toolbar orientation="horizontal">
+      <DropdownMenu
+        trigger="click"
+        options={defaultOptions}
+        onSelect={() => {}}
+        as="div"
+      >
+        <Toolbar.Item title="Filters">
+          <FaFilter />
+        </Toolbar.Item>
+      </DropdownMenu>
+    </Toolbar>
   );
 }


### PR DESCRIPTION
I'm not really sure if it's the best way to do. At some point it could be nice to switch from headless to radix as the component could benefit from the `asChild` prop of trigger's.