### PR TITLE
fix: only render modal children after calling showModal

### DIFF
--- a/src/components/hooks/useOnOff.ts
+++ b/src/components/hooks/useOnOff.ts
@@ -4,9 +4,8 @@ export function useOnOff(
   initialValue = false,
 ): [isOn: boolean, setOn: () => void, setOff: () => void, toggle: () => void] {
   const [isOn, setOnOff] = useState(initialValue);
-
   const setOn = useCallback(() => setOnOff(true), []);
   const setOff = useCallback(() => setOnOff(false), []);
-  const toggle = useCallback(() => setOnOff(!isOn), [isOn]);
+  const toggle = useCallback(() => setOnOff((isOn) => !isOn), []);
   return [isOn, setOn, setOff, toggle];
 }

--- a/src/components/modal/ConfirmModal.tsx
+++ b/src/components/modal/ConfirmModal.tsx
@@ -79,7 +79,7 @@ export function ConfirmModal(props: ConfirmModalProps) {
   } = props;
 
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const dialogProps = useDialog({
+  const { dialogProps, isModalShown } = useDialog({
     dialogRef,
     isOpen,
     requestCloseOnEsc,
@@ -104,36 +104,41 @@ export function ConfirmModal(props: ConfirmModalProps) {
   return (
     <Portal>
       <ConfirmModalDialog {...dialogProps} ref={dialogRef}>
-        <RootLayoutProvider innerRef={portalDomNode}>
-          <ConfirmModalContents headerColor={headerColor} style={{ maxWidth }}>
-            <ConfirmModalChildrenRoot headerColor={headerColor}>
-              {children}
-            </ConfirmModalChildrenRoot>
+        {isModalShown && (
+          <RootLayoutProvider innerRef={portalDomNode}>
+            <ConfirmModalContents
+              headerColor={headerColor}
+              style={{ maxWidth }}
+            >
+              <ConfirmModalChildrenRoot headerColor={headerColor}>
+                {children}
+              </ConfirmModalChildrenRoot>
 
-            <ConfirmModalFooter>
-              <Button
-                onClick={onConfirm}
-                backgroundColor={{
-                  basic: 'hsla(243deg, 75%, 58%, 1)',
-                  hover: 'hsla(245deg, 58%, 50%, 1)',
-                }}
-                color={{ basic: 'white' }}
-              >
-                {saveText}
-              </Button>
-              <Button
-                onClick={onCancel}
-                backgroundColor={{
-                  basic: 'hsla(0deg, 72%, 50%, 1)',
-                  hover: 'hsla(0deg, 73%, 42%, 1)',
-                }}
-                color={{ basic: 'white' }}
-              >
-                {cancelText}
-              </Button>
-            </ConfirmModalFooter>
-          </ConfirmModalContents>
-        </RootLayoutProvider>
+              <ConfirmModalFooter>
+                <Button
+                  onClick={onConfirm}
+                  backgroundColor={{
+                    basic: 'hsla(243deg, 75%, 58%, 1)',
+                    hover: 'hsla(245deg, 58%, 50%, 1)',
+                  }}
+                  color={{ basic: 'white' }}
+                >
+                  {saveText}
+                </Button>
+                <Button
+                  onClick={onCancel}
+                  backgroundColor={{
+                    basic: 'hsla(0deg, 72%, 50%, 1)',
+                    hover: 'hsla(0deg, 73%, 42%, 1)',
+                  }}
+                  color={{ basic: 'white' }}
+                >
+                  {cancelText}
+                </Button>
+              </ConfirmModalFooter>
+            </ConfirmModalContents>
+          </RootLayoutProvider>
+        )}
       </ConfirmModalDialog>
     </Portal>
   );

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -76,7 +76,7 @@ export function Modal(props: ModalProps) {
   } = props;
 
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const dialogProps = useDialog({
+  const { dialogProps, isModalShown } = useDialog({
     dialogRef,
     isOpen,
     requestCloseOnEsc,
@@ -101,18 +101,20 @@ export function Modal(props: ModalProps) {
   return (
     <Portal>
       <DialogRoot {...dialogProps} ref={dialogRef}>
-        <RootLayoutProvider innerRef={portalDomNode}>
-          <DialogContents
-            style={{
-              maxWidth,
-              height: height || 'max-content',
-              width: width || '100%',
-            }}
-          >
-            {children}
-            {hasCloseButton && <ModalCloseButton onClick={onRequestClose} />}
-          </DialogContents>
-        </RootLayoutProvider>
+        {isModalShown && (
+          <RootLayoutProvider innerRef={portalDomNode}>
+            <DialogContents
+              style={{
+                maxWidth,
+                height: height || 'max-content',
+                width: width || '100%',
+              }}
+            >
+              {children}
+              {hasCloseButton && <ModalCloseButton onClick={onRequestClose} />}
+            </DialogContents>
+          </RootLayoutProvider>
+        )}
       </DialogRoot>
     </Portal>
   );

--- a/stories/components/modal.stories.tsx
+++ b/stories/components/modal.stories.tsx
@@ -10,6 +10,7 @@ import {
   FaNpm,
   FaNodeJs,
 } from 'react-icons/fa';
+import { StructureEditor } from 'react-ocl/full';
 
 import {
   Accordion,
@@ -274,6 +275,23 @@ WithComplexContents.args = {
 };
 
 WithComplexContents.argTypes = actions;
+
+export function DynamicallySizedChildren() {
+  const [isOpen, open, close] = useOnOff(false);
+  return (
+    <div style={{ margin: '2em' }}>
+      <Button onClick={open}>Open editor modal</Button>
+      <Modal width={700} height={500} isOpen={isOpen} onRequestClose={close}>
+        <Modal.Header>Test OCL editor in modal</Modal.Header>
+        <Modal.Body>
+          <StructureEditor width={600} height={400} svgMenu />
+        </Modal.Body>
+      </Modal>
+    </div>
+  );
+}
+
+DynamicallySizedChildren.storyName = 'With dynamically sized children';
 
 function DemoPage(props: { openModal: () => void }) {
   return (


### PR DESCRIPTION
This is important when the children measure their size dynamically when
they are mounted. The OCL editor does it.
