### PR TITLE
fix: disable auto-translate of applications

### DIFF
--- a/src/components/root-layout/RootLayout.tsx
+++ b/src/components/root-layout/RootLayout.tsx
@@ -33,7 +33,7 @@ export function RootLayout(props: RootLayoutProps) {
   }, []);
 
   return (
-    <div style={{ ...style, ...props.style }}>
+    <div style={{ ...style, ...props.style }} translate="no">
       <CustomDivPreflight ref={ref}>
         <RootLayoutProvider innerRef={rootRef}>
           <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
This leads to random crashes because browser translation manipulates the
DOM in a way that React can be confused.
