### PR TITLE
fix: disable button tooltips with empty content

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -18,7 +18,7 @@ type BlueprintProps = {
     BlueprintAnchorButtonProps[key];
 };
 export type ButtonProps = BlueprintProps & {
-  tooltipProps?: Omit<TooltipProps, 'children'>;
+  tooltipProps?: Partial<Omit<TooltipProps, 'children'>>;
   tag?: ReactNode;
   tagProps?: Omit<TagProps, 'children'>;
 };

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -24,20 +24,20 @@ export type ButtonProps = BlueprintProps & {
 };
 
 export function Button(props: ButtonProps) {
-  const { tooltipProps, children, tag, tagProps, ...buttonProps } = props;
+  const { tooltipProps = {}, children, tag, tagProps, ...buttonProps } = props;
   const {
     fill,
     content = '',
-    disabled = false,
+    disabled = !tooltipProps.content,
     ...otherToolTipProps
-  } = tooltipProps || {};
+  } = tooltipProps;
   const InnerButton = buttonProps.disabled
     ? BlueprintAnchorButton
     : BlueprintButton;
   return (
     <Tooltip
       fill={fill || buttonProps.fill}
-      disabled={!content ? true : disabled}
+      disabled={disabled}
       content={content}
       {...otherToolTipProps}
       renderTarget={({ isOpen, ...targetProps }) => (

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -25,14 +25,21 @@ export type ButtonProps = BlueprintProps & {
 
 export function Button(props: ButtonProps) {
   const { tooltipProps, children, tag, tagProps, ...buttonProps } = props;
-
+  const {
+    fill,
+    content = '',
+    disabled = false,
+    ...otherToolTipProps
+  } = tooltipProps || {};
   const InnerButton = buttonProps.disabled
     ? BlueprintAnchorButton
     : BlueprintButton;
   return (
     <Tooltip
-      fill={tooltipProps?.fill || buttonProps.fill}
-      {...tooltipProps}
+      fill={fill || buttonProps.fill}
+      disabled={!content ? true : disabled}
+      content={content}
+      {...otherToolTipProps}
       renderTarget={({ isOpen, ...targetProps }) => (
         <div style={{ position: 'relative' }}>
           {tag && (


### PR DESCRIPTION
We have a warning in the console from Blueprint.js when the button component is used with empty tooltip content. To prevent this, we should disable the tooltip if its content is empty, which makes sense since an empty tooltip should be avoided.

I believe Blueprint.js should disable the tooltip by default if the content is empty.