### PR TITLE
feat: improve useSelect hook item render

### DIFF
--- a/src/components/hooks/useSelect.tsx
+++ b/src/components/hooks/useSelect.tsx
@@ -9,16 +9,16 @@ type FilterType<SourceType, Type> = Pick<
   }[keyof SourceType]
 >;
 
-interface ItemRenderOptions<T> {
+interface ItemOptions<T> {
   renderItem?: (item: T) => ReactNode;
   defaultSelectedItem?: T;
 }
 
-interface BaseOptions<T> extends ItemRenderOptions<T> {
+interface BaseOptions<T> extends ItemOptions<T> {
   itemTextKey: keyof FilterType<T, string>;
 }
 
-interface RenderOptions<T> extends ItemRenderOptions<T> {
+interface RenderOptions<T> extends ItemOptions<T> {
   getItemText: (item: T) => string;
 }
 
@@ -95,13 +95,12 @@ function getItemRenderer<T>(value: T, options: SelectOptions<T>) {
   ) => {
     const label = getLabel(item, options);
     const { renderItem } = options;
-    const isSelected = selectedLabel === label;
     const { active, disabled } = modifiers;
     return (
       <MenuItem
-        active={active && isSelected}
+        active={active}
         disabled={disabled}
-        selected={isSelected}
+        selected={selectedLabel === label}
         key={index}
         onClick={handleClick}
         onFocus={handleFocus}

--- a/src/components/hooks/useSelect.tsx
+++ b/src/components/hooks/useSelect.tsx
@@ -9,19 +9,20 @@ type FilterType<SourceType, Type> = Pick<
   }[keyof SourceType]
 >;
 
-interface BaseOptions<T> {
-  itemTextKey: keyof FilterType<T, string>;
-  defaultSelectedItem?: T;
-}
-
-interface RenderOptions<T> {
-  getItemText: (item: T) => string;
-  defaultSelectedItem?: T;
-}
-
-type SelectOptions<T> = {
+interface ItemRenderOptions<T> {
   renderItem?: (item: T) => ReactNode;
-} & (BaseOptions<T> | RenderOptions<T>);
+  defaultSelectedItem?: T;
+}
+
+interface BaseOptions<T> extends ItemRenderOptions<T> {
+  itemTextKey: keyof FilterType<T, string>;
+}
+
+interface RenderOptions<T> extends ItemRenderOptions<T> {
+  getItemText: (item: T) => string;
+}
+
+type SelectOptions<T> = BaseOptions<T> | RenderOptions<T>;
 
 function isAccessLabelByKey<T>(
   options: SelectOptions<T>,

--- a/src/components/hooks/useSelect.tsx
+++ b/src/components/hooks/useSelect.tsx
@@ -1,6 +1,6 @@
 import { MenuItem } from '@blueprintjs/core';
 import { ItemRenderer } from '@blueprintjs/select';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 type FilterType<SourceType, Type> = Pick<
   SourceType,
@@ -19,7 +19,9 @@ interface RenderOptions<T> {
   defaultSelectedItem?: T;
 }
 
-type SelectOptions<T> = BaseOptions<T> | RenderOptions<T>;
+type SelectOptions<T> = {
+  renderItem?: (item: T) => ReactNode;
+} & (BaseOptions<T> | RenderOptions<T>);
 
 function isAccessLabelByKey<T>(
   options: SelectOptions<T>,
@@ -91,16 +93,18 @@ function getItemRenderer<T>(value: T, options: SelectOptions<T>) {
     { handleClick, handleFocus, modifiers, index },
   ) => {
     const label = getLabel(item, options);
+    const { renderItem } = options;
+    const isSelected = selectedLabel === label;
     return (
       <MenuItem
-        active={modifiers.active}
+        active={isSelected}
         disabled={modifiers.disabled}
-        selected={selectedLabel === label}
+        selected={isSelected}
         key={index}
         onClick={handleClick}
         onFocus={handleFocus}
         roleStructure="listoption"
-        text={label}
+        text={renderItem?.(item) || label}
       />
     );
   };

--- a/src/components/hooks/useSelect.tsx
+++ b/src/components/hooks/useSelect.tsx
@@ -95,10 +95,11 @@ function getItemRenderer<T>(value: T, options: SelectOptions<T>) {
     const label = getLabel(item, options);
     const { renderItem } = options;
     const isSelected = selectedLabel === label;
+    const { active, disabled } = modifiers;
     return (
       <MenuItem
-        active={isSelected}
-        disabled={modifiers.disabled}
+        active={active && isSelected}
+        disabled={disabled}
         selected={isSelected}
         key={index}
         onClick={handleClick}

--- a/stories/components/select.stories.tsx
+++ b/stories/components/select.stories.tsx
@@ -6,7 +6,14 @@ import {
   MenuItem,
 } from '@blueprintjs/core';
 import { ItemListRenderer, Select } from '@blueprintjs/select';
-import { Dispatch, Fragment, SetStateAction, useState } from 'react';
+import styled from '@emotion/styled';
+import {
+  CSSProperties,
+  Dispatch,
+  Fragment,
+  SetStateAction,
+  useState,
+} from 'react';
 
 import { Button, useOnOff, useSelect } from '../../src/components';
 
@@ -371,6 +378,73 @@ export function WithCustomStyle() {
         filterable={false}
         itemsEqual="label"
         popoverContentProps={{ style: { width: '500px' } }}
+        {...defaultProps}
+      >
+        <Button
+          style={{ width: '500px' }}
+          text={value?.label ?? 'Select a status'}
+          rightIcon="double-caret-vertical"
+        />
+      </Select>
+      <p>Value outside component is {value?.label}.</p>
+    </>
+  );
+}
+
+const Row = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+});
+
+const Tag = styled.div({
+  borderRadius: '25px',
+  minWidth: '25px',
+  minHeight: '25px',
+  display: 'flex',
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: "11px",
+});
+
+export function WithCustomRenderItem() {
+  const { value, ...defaultProps } = useSelect<{
+    label: string;
+    color: CSSProperties['color'];
+  }>({
+    itemTextKey: 'label',
+    renderItem: ({ label, color }) => (
+      <Row>
+        <Tag
+          style={{
+            backgroundColor: color,
+          }}
+        >
+          <span>{label.charAt(0)}</span>
+        </Tag>
+        <span style={{ flex: 1, padding: '0 5px' }}>{label}</span>
+        <Tag
+          style={{
+            border: `${color} 1px solid`,
+            padding: '0 10px',
+          }}
+        >
+          <span>
+            fruits
+          </span>
+        </Tag>
+      </Row>
+    ),
+  });
+  return (
+    <>
+      <Select
+        items={[
+          { label: 'Apple', color: 'greenyellow' },
+          { label: 'Banana', color: 'yellow' },
+          { label: 'Orange', color: 'orange' },
+        ]}
+        filterable={false}
+        itemsEqual="label"
         {...defaultProps}
       >
         <Button

--- a/stories/components/select.stories.tsx
+++ b/stories/components/select.stories.tsx
@@ -401,9 +401,9 @@ const Tag = styled.div({
   minWidth: '25px',
   minHeight: '25px',
   display: 'flex',
-  alignItems: "center",
-  justifyContent: "center",
-  fontSize: "11px",
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '11px',
 });
 
 export function WithCustomRenderItem() {
@@ -428,9 +428,7 @@ export function WithCustomRenderItem() {
             padding: '0 10px',
           }}
         >
-          <span>
-            fruits
-          </span>
+          <span>fruits</span>
         </Tag>
       </Row>
     ),


### PR DESCRIPTION
In some cases, we need more than just text in the menu items, we require additional elements, as seen in the workspaces dropdown menu in NMRium. Therefore, I suggest enhancing the useSelect hook to support custom item rendering. I don't want to replace the entire MenuItem; I just need the ability to customize its content.