### PR TITLE
fix: remove dependency on d3-scale-chromatic types

### DIFF
--- a/src/components/color-picker/gradient-select/GradientSelect.tsx
+++ b/src/components/color-picker/gradient-select/GradientSelect.tsx
@@ -7,15 +7,23 @@ import { FaChevronDown } from 'react-icons/fa';
 
 import FixedGradientPreview from '../preview/FixedGradientPreview';
 
-export const fixedGradientScales = {
+export type GradientScaleName =
+  | 'turbo'
+  | 'viridis'
+  | 'inferno'
+  | 'magma'
+  | 'plasma';
+
+export const fixedGradientScales: Record<
+  GradientScaleName,
+  (t: number) => string
+> = {
   turbo: scaleChromatic.interpolateTurbo,
   viridis: scaleChromatic.interpolateViridis,
   inferno: scaleChromatic.interpolateInferno,
   magma: scaleChromatic.interpolateMagma,
   plasma: scaleChromatic.interpolatePlasma,
 };
-
-export type GradientScaleName = keyof typeof fixedGradientScales;
 
 const scaleOptions = Object.keys(fixedGradientScales) as GradientScaleName[];
 


### PR DESCRIPTION
The other solution would be to add `@types/d3-scale-chromatic` to the prod dependencies
but I find it better to not implicitly depend on it through the public API.
