### PR TITLE
fix: toolbar popover item should have backdrop to avoid interactions outside of it when it is open

### DIFF
--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -247,6 +247,7 @@ Toolbar.PopoverItem = function ToolbarPopoverItem(
       disabled={disabled}
       placement={vertical ? 'right-start' : 'bottom-start'}
       interactionKind={popoverInteractionKind}
+      hasBackdrop
       hoverCloseDelay={0}
       css={css`
         .${Classes.ICON} {


### PR DESCRIPTION
Closes: https://github.com/zakodium-oss/react-science/issues/725
