### PR TITLE
fix: include alpha in hex code for semi-transparent colors

### DIFF
--- a/src/components/color-picker/react-color/helpers/color.js
+++ b/src/components/color-picker/react-color/helpers/color.js
@@ -27,16 +27,23 @@ function toState(data, oldHue) {
   const hsl = color.toHsl();
   const hsv = color.toHsv();
   const rgb = color.toRgb();
-  const hex = color.toHex();
+
+  let hex;
+
+  if (rgb.a < 1) {
+    hex = color.toHex8();
+  } else {
+    hex = color.toHex();
+  }
+
   if (hsl.s === 0) {
     hsl.h = oldHue || 0;
     hsv.h = oldHue || 0;
   }
-  const transparent = hex === '000000' && rgb.a === 0;
 
   return {
     hsl,
-    hex: transparent ? 'transparent' : `#${hex}`,
+    hex: `#${hex}`,
     rgb,
     hsv,
     oldHue: data.h || oldHue || hsl.h,


### PR DESCRIPTION
I updated the `toState` function which is responsible for managing the color on the color picker component to include the alpha channel in the hex color when the alpha is less than 100%.

- Hex format is 8 characters (#RRGGBBAA) for colors with transparency.
- In case the (alpha = 100%), the hex format remains 6 characters (#RRGGBB).
