### PR TITLE
fix: use relative position on toolbar popover items

### DIFF
--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -274,9 +274,10 @@ Toolbar.PopoverItem = function ToolbarPopoverItem(
           height: 'fit-content',
         },
       }}
-      renderTarget={() => <Toolbar.Item isPopover {...itemProps} />}
       {...other}
-    />
+    >
+      <Toolbar.Item isPopover {...itemProps} />
+    </Popover>
   );
 };
 


### PR DESCRIPTION
Blueprint's popover targetProps prop is ignored when rendering the target with `renderTarget`. Must use `children` prop instead.

Closes: https://github.com/zakodium-oss/react-science/issues/773
