### PR TITLE
Switch from radix to blueprint

### DIFF
--- a/src/components/info-panel/InfoPanel.tsx
+++ b/src/components/info-panel/InfoPanel.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
-import { Icon, InputGroup } from '@blueprintjs/core';
+import { Collapse, Colors, InputGroup } from '@blueprintjs/core';
 import { css } from '@emotion/react';
-import * as Collapsible from '@radix-ui/react-collapsible';
 import {
   type CSSProperties,
   memo,
@@ -10,6 +9,7 @@ import {
   useState,
 } from 'react';
 
+import { Button } from '../button/Button.js';
 import { SelectedTotal } from '../selected-total/index.js';
 import { createTableColumnHelper, Table } from '../table/index.js';
 import * as ValueRenderers from '../value-renderers/index.js';
@@ -55,28 +55,27 @@ const style = {
     display: 'flex',
     flexDirection: 'column',
   }),
-  chevron: css({
-    transition: 'all 0.3s ease-in-out',
-  }),
-  button: css({
-    zIndex: 10,
-    position: 'sticky',
-    height: 30,
-    top: 0,
-    "&[data-state='open'] > span": {
-      rotate: '90deg',
-    },
-    cursor: 'pointer',
-    borderBottom: '1px solid #f5f5f5',
-    backgroundColor: 'white',
-    display: 'flex',
-    alignItems: 'center',
-    padding: '5px 2px',
-    width: '100%',
-    ':hover': {
-      backgroundColor: '#f5f5f5',
-    },
-  }),
+  button: (open: boolean) =>
+    css({
+      backgroundColor: `${Colors.LIGHT_GRAY5} !important`,
+      zIndex: 10,
+      position: 'sticky',
+      height: 30,
+      top: 0,
+      '& .bp5-icon': {
+        rotate: open ? '90deg' : '',
+        transition: 'all 0.3s ease-in-out',
+      },
+      cursor: 'pointer',
+      borderBottom: '1px solid #f5f5f5',
+      display: 'flex',
+      alignItems: 'center',
+      padding: '5px 2px',
+      width: '100%',
+      ':hover': {
+        backgroundColor: `${Colors.LIGHT_GRAY4} !important`,
+      },
+    }),
 };
 
 interface InfoPanelDatum {
@@ -209,6 +208,7 @@ interface InfoPanelContentProps {
 }
 
 const InfoPanelContent = memo((props: InfoPanelContentProps) => {
+  const [isOpen, setIsOpen] = useState<string[]>([]);
   const { filteredData } = props;
   return (
     <div
@@ -222,19 +222,25 @@ const InfoPanelContent = memo((props: InfoPanelContentProps) => {
       }}
     >
       {filteredData.map(({ description, data }) => {
+        const open = isOpen.includes(description);
         return (
-          <Collapsible.Root
-            key={description}
-            className="CollapsibleRoot"
-            defaultOpen
-          >
-            <Collapsible.Trigger asChild css={style.button}>
-              <div>
-                <Icon icon="chevron-right" css={style.chevron} />
-                {description}
-              </div>
-            </Collapsible.Trigger>
-            <Collapsible.Content css={style.content}>
+          <div key={description}>
+            <Button
+              minimal
+              css={style.button(open)}
+              onClick={() =>
+                setIsOpen((pred) =>
+                  open
+                    ? pred.filter((o) => o !== description)
+                    : [...pred, description],
+                )
+              }
+              alignText="left"
+              icon="chevron-right"
+            >
+              {description}
+            </Button>
+            <Collapse isOpen={open} css={style.content}>
               <Table
                 data={data}
                 columns={columns}
@@ -242,8 +248,8 @@ const InfoPanelContent = memo((props: InfoPanelContentProps) => {
                 tableProps={{ style: { width: '100%' } }}
                 compact
               />
-            </Collapsible.Content>
-          </Collapsible.Root>
+            </Collapse>
+          </div>
         );
       })}
     </div>

--- a/stories/components/radio.stories.tsx
+++ b/stories/components/radio.stories.tsx
@@ -1,7 +1,10 @@
+/** @jsxImportSource @emotion/react */
 import {
   RadioGroup as BlueprintjsRadioGroup,
+  Radio,
   type RadioGroupProps as BlueprintjsRadioGroupProps,
 } from '@blueprintjs/core';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
@@ -56,6 +59,98 @@ ControlBlueprint.args = {
   disabled: false,
   inline: false,
 };
+
+const enabledColor = '#1677ff';
+
+const storyStyles = {
+  radioGroup: css({
+    display: 'flex',
+    flexDirection: 'row',
+    width: 'fit-content',
+    ' & > *:first-of-type, & > *:first-of-type span': {
+      borderRadius: '6px 0 0 6px',
+    },
+    ' & > *:last-of-type, & > *:last-of-type span': {
+      borderRightWidth: 1,
+      borderRadius: '0 6px 6px 0',
+    },
+  }),
+  radio: css({
+    border: '1px solid hsla(0, 0%, 0%, 0.25)',
+    borderRightWidth: 0,
+    position: 'relative',
+    paddingLeft: '0 !important',
+    '.bp5-control-indicator': {
+      display: 'none',
+    },
+    'input[type="radio"]:checked': {
+      '& ~ div': {
+        color: enabledColor,
+      },
+      '& ~ span': {
+        border: `1px solid ${enabledColor} !important`,
+      },
+    },
+    span: {
+      position: 'absolute',
+      top: -1,
+      left: -1,
+      right: -1,
+      bottom: -1,
+      zIndex: 10,
+      borderWidth: '0 !important',
+    },
+  }),
+  item: (disabled?: boolean) =>
+    css({
+      opacity: disabled ? 0.25 : 1,
+      padding: '0px 15px',
+      width: '100%',
+      height: '100%',
+      cursor: 'pointer',
+      ':hover': {
+        '& > label': {
+          color: disabled ? '' : enabledColor,
+        },
+      },
+      fontSize: '1.125em',
+      lineHeight: '30px',
+    }),
+};
+
+export function ButtonRadionBlueprint() {
+  const [option, setOption] = useState(options[2]);
+  return (
+    <ExampleGroup>
+      <BlueprintjsRadioGroup
+        onChange={(event) => {
+          const value = event.currentTarget.value;
+          setOption(
+            (option) => options.find((o) => o.value === value) || option,
+          );
+        }}
+        selectedValue={option.value}
+        name="button-radio"
+        css={storyStyles.radioGroup}
+      >
+        {options.map((o) => (
+          <Radio
+            name="button-radio"
+            value={o.value}
+            disabled={o.disabled}
+            id={o.value}
+            key={o.value}
+            css={storyStyles.radio}
+          >
+            <div css={storyStyles.item(o.disabled)}>{o.label}</div>
+            <span />
+          </Radio>
+        ))}
+      </BlueprintjsRadioGroup>
+    </ExampleGroup>
+  );
+}
+
 export function ControlButton(
   props: Omit<RadioGroupProps, 'options' | 'selected' | 'onSelect' | 'name'>,
 ) {


### PR DESCRIPTION
closes : https://github.com/zakodium-oss/react-science/issues/469


For the RadioGroup component, I created the same we have with BluePrintJs
Either we update ours and make it use BluePrintJs instead of radix or just remove the component because it can be done using BluePrintJs

Technically I prefer we update ours because recreating it with BluePrintJs is not simple.