### PR TITLE
fix: review toolbar item props

### DIFF
--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -54,7 +54,10 @@ export interface ToolbarItemProps
       event: MouseEvent;
     },
   ) => void;
-  isPopover?: boolean;
+}
+
+interface ToolbarItemInternalProps extends ToolbarItemProps {
+  isPopover: boolean;
 }
 
 export interface ToolbarPopoverItemProps extends PopoverProps {
@@ -128,7 +131,11 @@ export function Toolbar(props: ToolbarProps) {
   );
 }
 
-Toolbar.Item = function ToolbarItem(props: ToolbarItemProps) {
+function ToolbarItem(props: ToolbarItemProps) {
+  return <ToolbarItemInternal {...props} isPopover={false} />;
+}
+
+function ToolbarItemInternal(props: ToolbarItemInternalProps) {
   const {
     active = false,
     icon,
@@ -231,7 +238,9 @@ Toolbar.Item = function ToolbarItem(props: ToolbarItemProps) {
       {...other}
     />
   );
-};
+}
+
+Toolbar.Item = ToolbarItem;
 
 Toolbar.PopoverItem = function ToolbarPopoverItem(
   props: ToolbarPopoverItemProps,
@@ -261,7 +270,7 @@ Toolbar.PopoverItem = function ToolbarPopoverItem(
       }}
       renderTarget={({ isOpen, className, ...targetProps }) => (
         <span {...targetProps} style={{ flex: '0 0 auto' }}>
-          <Toolbar.Item isPopover {...itemProps} />
+          <ToolbarItemInternal isPopover {...itemProps} />
         </span>
       )}
       {...other}

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -49,11 +49,7 @@ export interface ToolbarItemProps
     Pick<ButtonProps, 'id' | 'icon' | 'active' | 'tag' | 'tagProps'> {
   tooltip?: TooltipProps['content'];
   tooltipProps?: Omit<TooltipProps, 'content'>;
-  onClick?: (
-    item: ToolbarItemProps & {
-      event: MouseEvent;
-    },
-  ) => void;
+  onClick?: (event: MouseEvent) => void;
 }
 
 interface ToolbarItemInternalProps extends ToolbarItemProps {
@@ -220,9 +216,7 @@ function ToolbarItemInternal(props: ToolbarItemInternalProps) {
           )}
         </div>
       }
-      onClick={(event) => {
-        onClick?.({ event, ...props });
-      }}
+      onClick={onClick}
       tooltipProps={
         !tooltip
           ? undefined

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -41,6 +41,12 @@ interface ToolbarBaseProps {
 export interface ToolbarProps
   extends ToolbarBaseProps,
     Pick<ButtonGroupProps, 'children' | 'vertical'> {
+  /**
+   * The type of interaction which triggers a popover to open.
+   * This prop only affects children which are `Toolbar.PopoverItem`.
+   *
+   * {@link https://blueprintjs.com/docs/#core/components/popover.interactions}
+   */
   popoverInteractionKind?: PopoverInteractionType;
 }
 

--- a/stories/components/accordion.stories.tsx
+++ b/stories/components/accordion.stories.tsx
@@ -57,7 +57,7 @@ export function Fixed() {
                   id={item.id}
                   tooltip={item.tooltip}
                   icon={item.icon}
-                  onClick={({ event }) => {
+                  onClick={(event) => {
                     event?.stopPropagation();
                   }}
                 />

--- a/stories/components/toolbar.stories.tsx
+++ b/stories/components/toolbar.stories.tsx
@@ -9,12 +9,12 @@ import {
   ActivityBar,
   ActivityBarItem,
   ActivityPanel,
+  type PopoverInteractionType,
   SplitPane,
   Toolbar,
-  TooltipHelpContent,
-  type PopoverInteractionType,
   type ToolbarItemProps,
   type ToolbarProps,
+  TooltipHelpContent,
   type TooltipItem,
 } from '../../src/components/index.js';
 
@@ -290,11 +290,9 @@ export function WithTag() {
   );
 }
 export function Vertical() {
-  const [state, setState] = useState(itemsBlueprintIcons[1]);
-  function handleChange({ id, icon, tooltip }: ToolbarItemProps) {
-    setState({ id: id as string, icon, tooltip });
-  }
+  const [selected, setSelected] = useState(itemsBlueprintIcons[1].id);
 
+  const selectedItem = itemsBlueprintIcons.find((item) => item.id === selected);
   return (
     <div
       style={{
@@ -311,28 +309,29 @@ export function Vertical() {
             key={item.id}
             id={item.id}
             tooltip={item.tooltip}
-            active={state.tooltip === item.tooltip}
-            onClick={handleChange}
+            active={selected === item.id}
+            onClick={() => {
+              setSelected(item.id);
+            }}
             icon={item.icon}
           />
         ))}
         <Toolbar.Item tooltip="Inbox" icon="inbox" />
       </Toolbar>
-      <div style={{ padding: 5 }}>
-        <p>Hello, World!</p>
-        <p>Value selected: {state.tooltip}</p>
-      </div>
+      {selectedItem && (
+        <div style={{ padding: 5 }}>
+          <p>Hello, World!</p>
+          <p>Value selected: {selectedItem.tooltip}</p>
+        </div>
+      )}
     </div>
   );
 }
 
 export function Horizontal() {
-  const [state, setState] = useState(itemsBlueprintIcons[1]);
+  const [selected, setSelected] = useState(itemsBlueprintIcons[1].id);
 
-  function handleChange({ id, icon, tooltip }: ToolbarItemProps) {
-    setState({ id: id as string, icon, tooltip });
-  }
-
+  const selectedItem = itemsBlueprintIcons.find((item) => item.id === selected);
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <Toolbar intent="primary" disabled={false}>
@@ -341,18 +340,22 @@ export function Horizontal() {
             key={item.id}
             id={item.id}
             tooltip={item.tooltip}
-            active={state.id === item.id}
-            onClick={handleChange}
+            active={selected === item.id}
+            onClick={() => {
+              setSelected(item.id);
+            }}
             icon={item.icon}
             intent={item.id === 'test5' ? 'danger' : undefined}
             disabled={item.disabled ?? undefined}
           />
         ))}
       </Toolbar>
-      <div style={{ padding: 5 }}>
-        <p>Hello, World!</p>
-        <p>Value selected: {state.tooltip}</p>
-      </div>
+      {selectedItem && (
+        <div style={{ padding: 5 }}>
+          <p>Hello, World!</p>
+          <p>Value selected: {selectedItem.tooltip}</p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- **fix: do not expose the isPopover prop**
- **fix(toolbar): do not pass item props in onClick callback**
- **docs(toolbar): add JSDoc to explain the `popoverInteractionKind` prop**

Closes: https://github.com/zakodium-oss/react-science/issues/704