### PR TITLE
fix(button): correct default height of buttons

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -44,6 +44,10 @@ export function Button(props: ButtonProps) {
       renderTarget={({ isOpen, ...targetProps }) => (
         <InnerButton
           css={css({
+            // Setting the line-height makes sure regular sized buttons have a
+            // height consistent with the input fields and across variants.
+            // Using the same line height as in the blueprint docs.
+            lineHeight: 1.15,
             position: 'relative',
             '.bp5-icon': !children && {
               marginRight: '0',


### PR DESCRIPTION
Make sure it's consistent across button variants, and by default results in the same height as inputs.

The height of the different variants of buttons are now consistent with the sizes observed in blueprintjs' documentation.

Closes: https://github.com/zakodium-oss/react-science/issues/743
