### PR TITLE
feat: add renderHeaderCell prop to `Table` component

### DIFF
--- a/src/components/table/table_header.tsx
+++ b/src/components/table/table_header.tsx
@@ -1,6 +1,7 @@
 import type { Header, RowData } from '@tanstack/react-table';
 import type { CSSProperties } from 'react';
 
+import type { HeaderCellRenderer } from './table_header_cell.js';
 import { TableHeaderCell } from './table_header_cell.js';
 
 const headerStyle: CSSProperties = {
@@ -13,17 +14,22 @@ const headerStyle: CSSProperties = {
 interface TableHeaderProps<TData extends RowData> {
   headers: Array<Header<TData, unknown>>;
   sticky: boolean;
+  renderHeaderCell?: HeaderCellRenderer<TData>;
 }
 
 export function TableHeader<TData extends RowData>(
   props: TableHeaderProps<TData>,
 ) {
-  const { headers, sticky } = props;
+  const { headers, sticky, renderHeaderCell } = props;
   return (
     <thead style={sticky ? headerStyle : undefined}>
       <tr>
         {headers.map((header) => (
-          <TableHeaderCell key={header.id} header={header} />
+          <TableHeaderCell
+            key={header.id}
+            header={header}
+            renderHeaderCell={renderHeaderCell}
+          />
         ))}
       </tr>
     </thead>

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -2,12 +2,13 @@ import type { Header, RowData } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 
-// React type for table th props
-type ThProps = HTMLAttributes<HTMLTableCellElement>;
-type ProvidedThProps = Pick<ThProps, 'style' | 'onClick' | 'children'>;
+type ThProps = Pick<
+  HTMLAttributes<HTMLTableCellElement>,
+  'style' | 'onClick' | 'children'
+>;
 
 export type HeaderCellRenderer<TData extends RowData> = (
-  thProps: ProvidedThProps,
+  thProps: ThProps,
   header: Header<TData, unknown>,
 ) => ReactNode;
 
@@ -32,7 +33,7 @@ export function TableHeaderCell<TData extends RowData>(
 
 function getThProps<TData extends RowData>(
   header: Header<TData, unknown>,
-): ProvidedThProps {
+): ThProps {
   const sorted = header.column.getIsSorted();
   const canSort = header.column.getCanSort();
   const style: CSSProperties = {
@@ -42,7 +43,9 @@ function getThProps<TData extends RowData>(
   const onClick = canSort ? header.column.getToggleSortingHandler() : undefined;
   const children = (
     <div style={{ display: 'flex', flexDirection: 'row', gap: '5px' }}>
-      {flexRender(header.column.columnDef.header, header.getContext())}
+      <div>
+        {flexRender(header.column.columnDef.header, header.getContext())}
+      </div>
       {sorted
         ? {
             asc: '🔼',

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -1,39 +1,56 @@
 import type { Header, RowData } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+
+// React type for table th props
+type ThProps = HTMLAttributes<HTMLTableCellElement>;
+type ProvidedThProps = Pick<ThProps, 'style' | 'onClick' | 'children'>;
+
+export type HeaderCellRenderer<TData extends RowData> = (
+  thProps: ProvidedThProps,
+  header: Header<TData, unknown>,
+) => ReactNode;
 
 interface TableHeaderCellProps<TData extends RowData> {
   header: Header<TData, unknown>;
+  renderHeaderCell?: HeaderCellRenderer<TData>;
 }
 
 export function TableHeaderCell<TData extends RowData>(
   props: TableHeaderCellProps<TData>,
 ) {
-  const { header } = props;
-  const column = header.column;
+  const { header, renderHeaderCell } = props;
 
-  const canSort = column.getCanSort();
-  const sorted = column.getIsSorted();
+  const thProps = getThProps(header);
 
+  if (renderHeaderCell) {
+    return renderHeaderCell(thProps, header);
+  }
+
+  return <th {...thProps} />;
+}
+
+function getThProps<TData extends RowData>(
+  header: Header<TData, unknown>,
+): ProvidedThProps {
+  const sorted = header.column.getIsSorted();
+  const canSort = header.column.getCanSort();
   const style: CSSProperties = {
     position: 'relative',
     cursor: canSort ? 'pointer' : undefined,
   };
-
-  return (
-    <th
-      style={style}
-      onClick={canSort ? column.getToggleSortingHandler() : undefined}
-    >
-      <div style={{ display: 'flex', flexDirection: 'row', gap: '5px' }}>
-        {flexRender(header.column.columnDef.header, header.getContext())}
-        {sorted
-          ? {
-              asc: '🔼',
-              desc: '🔽',
-            }[sorted]
-          : null}
-      </div>
-    </th>
+  const onClick = canSort ? header.column.getToggleSortingHandler() : undefined;
+  const children = (
+    <div style={{ display: 'flex', flexDirection: 'row', gap: '5px' }}>
+      {flexRender(header.column.columnDef.header, header.getContext())}
+      {sorted
+        ? {
+            asc: '🔼',
+            desc: '🔽',
+          }[sorted]
+        : null}
+    </div>
   );
+
+  return { style, children, onClick };
 }

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -21,13 +21,11 @@ export function TableHeaderCell<TData extends RowData>(
   props: TableHeaderCellProps<TData>,
 ) {
   const { header, renderHeaderCell } = props;
-
   const thProps = getThProps(header);
 
   if (renderHeaderCell) {
     return renderHeaderCell(thProps, header);
   }
-
   return <th {...thProps} />;
 }
 

--- a/src/components/table/table_root.tsx
+++ b/src/components/table/table_root.tsx
@@ -75,7 +75,7 @@ interface TableBaseProps<TData extends RowData> {
    */
   renderRowTr?: TableRowTrRenderer<TData>;
   /**
-   * Override the default header row rendering.
+   * Override the columns' header cell rendering.
    */
   renderHeaderCell?: HeaderCellRenderer<TData>;
 }

--- a/src/components/table/table_root.tsx
+++ b/src/components/table/table_root.tsx
@@ -14,6 +14,7 @@ import { useRef } from 'react';
 
 import { TableBody } from './table_body.js';
 import { TableHeader } from './table_header.js';
+import type { HeaderCellRenderer } from './table_header_cell.js';
 import type { TableColumnDef, TableRowTrRenderer } from './table_utils.js';
 import { useTableColumns } from './use_table_columns.js';
 
@@ -73,6 +74,10 @@ interface TableBaseProps<TData extends RowData> {
    * Make sure to spread the passed `trProps` onto the rendered `<tr>` element.
    */
   renderRowTr?: TableRowTrRenderer<TData>;
+  /**
+   * Override the default header row rendering.
+   */
+  renderHeaderCell?: HeaderCellRenderer<TData>;
 }
 
 interface RegularTableProps<TData extends RowData>
@@ -109,6 +114,7 @@ export function Table<TData extends RowData>(props: TableProps<TData>) {
     reactTable,
     tableProps,
     renderRowTr,
+    renderHeaderCell,
 
     virtualizeRows,
   } = props;
@@ -141,7 +147,11 @@ export function Table<TData extends RowData>(props: TableProps<TData>) {
         striped={striped}
         {...tableProps}
       >
-        <TableHeader sticky={stickyHeader} headers={table.getFlatHeaders()} />
+        <TableHeader
+          sticky={stickyHeader}
+          headers={table.getFlatHeaders()}
+          renderHeaderCell={renderHeaderCell}
+        />
         <TableBody
           rows={table.getRowModel().rows}
           renderRowTr={renderRowTr}

--- a/stories/components/table.stories.tsx
+++ b/stories/components/table.stories.tsx
@@ -46,13 +46,16 @@ const columns = [
   columnHelper.accessor('ocl.idCode', {
     header: 'Molecule',
     cell: ({ getValue }) => <IdcodeSvgRenderer idcode={getValue()} />,
+    meta: { color: 'yellow', width: 400 },
   }),
   columnHelper.accessor('name', {
     header: 'Name',
     enableSorting: true,
-    cell: ({ getValue }) => (
-      <Truncate style={{ width: 200 }}>{getValue()}</Truncate>
-    ),
+    cell: ({ getValue }) => <Truncate>{getValue()}</Truncate>,
+    meta: {
+      color: 'lightblue',
+      width: 200,
+    },
   }),
   columnHelper.accessor('rn', { header: 'RN' }),
   columnHelper.accessor('mw', {
@@ -134,6 +137,42 @@ export function CustomTrRender({
       renderRowTr={(trProps, row) => (
         <tr {...trProps} style={{ backgroundColor: row.original.color }} />
       )}
+    />
+  );
+}
+
+export function CustomHeaderCellRender({
+  bordered,
+  compact,
+  interactive,
+  striped,
+  stickyHeader,
+}: ControlProps) {
+  return (
+    <Table
+      bordered={bordered}
+      compact={compact}
+      interactive={interactive}
+      striped={striped}
+      stickyHeader={stickyHeader}
+      columns={columns}
+      data={table}
+      tableProps={{
+        style: {
+          tableLayout: 'fixed',
+          width: '100%',
+        },
+      }}
+      renderHeaderCell={(thProps, header) => {
+        const backgroundColor = header.column.columnDef.meta?.color;
+        const width = header.column.columnDef.meta?.width;
+        return (
+          <th
+            {...thProps}
+            style={{ ...thProps.style, backgroundColor, width }}
+          />
+        );
+      }}
     />
   );
 }

--- a/stories/react-table.d.ts
+++ b/stories/react-table.d.ts
@@ -1,0 +1,11 @@
+import type { RowData } from '@tanstack/react-table';
+import type { CSSProperties } from 'react';
+
+declare module '@tanstack/react-table' {
+  // Declaration merging
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    color: CSSProperties['backgroundColor'];
+    width?: number;
+  }
+}


### PR DESCRIPTION
Example of use case: use a fixed layout table and set the width of certain columns by setting the header's width
