### PR TITLE
feat: create a proposal that check if features are enabled on browser

### DIFF
--- a/src/components/chack_navigator/check_navigator.tsx
+++ b/src/components/chack_navigator/check_navigator.tsx
@@ -1,0 +1,105 @@
+import { Icon } from '@blueprintjs/core';
+import styled from '@emotion/styled';
+import type { ReactNode } from 'react';
+import { createContext, useContext, useEffect } from 'react';
+
+interface NavigatorFeature {
+  name: string;
+  enabled: () => boolean;
+}
+
+interface CheckNavigatorProps {
+  fallbackComponent?: ReactNode;
+}
+
+const Table = styled.table`
+  border-collapse: collapse;
+  width: 100%;
+`;
+
+const TableHeadCell = styled.th`
+  border: 1px solid #cdcdcd;
+`;
+
+const TableCell = styled.td`
+  border: 1px solid #cdcdcd;
+  text-align: center;
+`;
+
+const FeatureIcon = styled(Icon)<{ icon: 'tick' | 'disable' }>`
+  color: ${(props) => (props.icon === 'tick' ? 'green' : 'red')};
+`;
+
+/*
+- [x] List of checks (array with identifier for monitoring and callback for check)
+- [ ] Do the checks before loading app
+- [x] Display a fallback component if check fails, asking to use a more modern browser
+
+On peu utiliser un Provider & context. check si les features sont activées tout en haut dans le dom via le provider.
+Ici on utilise juste les informations que on a passé au provider (et que on récupère via le state) pour les afficher
+
+ATTENTION je ne sais pas si dans ce cas, le check est fait avant le chargement de l'app.
+j'imagine que si je met le provider très haut, il est chargé avant tout le reste
+ */
+
+const context = createContext<NavigatorFeature[] | null>(null);
+
+interface CheckNavigatorProviderProps {
+  features: NavigatorFeature[];
+  children: ReactNode;
+}
+
+export function CheckNavigatorProvider(props: CheckNavigatorProviderProps) {
+  const { children, features } = props;
+
+  useEffect(() => {
+    for (const feature of features) {
+      if (!feature.enabled()) {
+        console.error(`Feature "${feature.name}" is not enabled`);
+      }
+    }
+  }, [features]);
+
+  return <context.Provider value={features}>{children}</context.Provider>;
+}
+
+function useCheckNavigatorFeatures() {
+  const ctx = useContext(context);
+
+  if (!ctx) {
+    throw new Error('CheckNavigatorProvider must be provided');
+  }
+
+  return ctx;
+}
+
+export function CheckNavigator(props: CheckNavigatorProps) {
+  const { fallbackComponent } = props;
+
+  const features = useCheckNavigatorFeatures();
+  const hasFeaturesFailed = features.some((feature) => !feature.enabled());
+  if (hasFeaturesFailed && fallbackComponent) {
+    return fallbackComponent;
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          {features.map((feature) => (
+            <TableHeadCell key={feature.name}>{feature.name}</TableHeadCell>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          {features.map((feature) => (
+            <TableCell key={feature.name}>
+              <FeatureIcon icon={feature.enabled() ? 'tick' : 'disable'} />
+            </TableCell>
+          ))}
+        </tr>
+      </tbody>
+    </Table>
+  );
+}

--- a/src/components/chack_navigator/index.ts
+++ b/src/components/chack_navigator/index.ts
@@ -1,0 +1,1 @@
+export * from './check_navigator.js';

--- a/stories/components/check_bar.stories.tsx
+++ b/stories/components/check_bar.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  CheckNavigator,
+  CheckNavigatorProvider,
+} from '../../src/components/chack_navigator/index.js';
+
+export default {
+  title: 'Components / CheckNavigator',
+  component: CheckNavigator,
+} as Meta;
+
+type Story = StoryObj<typeof CheckNavigator>;
+
+export const NavigatorFeatures = {
+  argTypes: {
+    fallbackComponent: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    fallbackComponent: (
+      <div>Some features are not enabled. Please use a more modern browser</div>
+    ),
+  },
+  decorators: (Story) => {
+    return (
+      <div style={{ padding: 10, width: 500 }}>
+        <CheckNavigatorProvider
+          features={[
+            {
+              name: 'structuredClone',
+              enabled: () => typeof structuredClone === 'function',
+            },
+            {
+              name: 'JSON.parse',
+              enabled: () => typeof JSON.parse === 'function',
+            },
+          ]}
+        >
+          <Story />
+        </CheckNavigatorProvider>
+      </div>
+    );
+  },
+} satisfies Story;
+
+export const WithFailAndFallback = {
+  argTypes: {
+    fallbackComponent: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    fallbackComponent: (
+      <div>Some features are not enabled. Please use a more modern browser</div>
+    ),
+  },
+  decorators: (Story) => {
+    return (
+      <div style={{ padding: 10, width: 500 }}>
+        <CheckNavigatorProvider
+          features={[
+            {
+              name: 'structuredClone',
+              enabled: () => typeof structuredClone === 'function',
+            },
+            { name: 'JSON.fail', enabled: () => false },
+          ]}
+        >
+          <Story />
+        </CheckNavigatorProvider>
+      </div>
+    );
+  },
+} satisfies Story;
+
+export const WithFail = {
+  argTypes: {
+    fallbackComponent: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  decorators: (Story) => {
+    return (
+      <div style={{ padding: 10, width: 500 }}>
+        <CheckNavigatorProvider
+          features={[
+            {
+              name: 'structuredClone',
+              enabled: () => typeof structuredClone === 'function',
+            },
+            { name: 'JSON.fail', enabled: () => false },
+          ]}
+        >
+          <Story />
+        </CheckNavigatorProvider>
+      </div>
+    );
+  },
+} satisfies Story;


### PR DESCRIPTION
I saw an issue opened from a long time without any push .. i wanted to contribute on it.
I thinked about something like that (for this issue https://github.com/zakodium-oss/react-science/issues/746).

`CheckNavigatorProvider` can be used at the top of the application. inside the for we can remove the console.error to do everything that we want !

the Table will use the context to render this :

When everything is ok
![CleanShot 2024-12-31 at 14 09 29](https://github.com/user-attachments/assets/0100806d-9e7e-420c-bfd1-68989a1bff33)

When something is ok and we wan't to render something else (like a message to the user)
![CleanShot 2024-12-31 at 14 10 08](https://github.com/user-attachments/assets/9d95a9ab-19ea-4711-858a-fd42927ff80c)

And this is when you have some check that fail. but without any render of messages
![CleanShot 2024-12-31 at 14 10 36](https://github.com/user-attachments/assets/dd0fcd51-5fc6-4304-8dcb-7576929fcbe0)

this is only a contribution. we can't go from that, or re-think everything !