### PR TITLE
fix: allow to search with `yes` or `no`

### DIFF
--- a/src/components/info-panel/InfoPanel.tsx
+++ b/src/components/info-panel/InfoPanel.tsx
@@ -109,9 +109,9 @@ export function InfoPanel(props: InfoPanelProps) {
       const includes: InfoPanelDatum[] = [];
       const valueContains: InfoPanelDatum[] = [];
 
-      for (const [parameter, value] of Object.entries(data).sort(([a], [b]) =>
-        a.localeCompare(b),
-      )) {
+      for (const [parameter, value] of Object.entries(data).sort(([a], [b]) => {
+        return a.localeCompare(b);
+      })) {
         const lowerKey = parameter.toLowerCase();
         const lowerSearch = search.toLowerCase();
         if (lowerKey === lowerSearch) {
@@ -277,7 +277,12 @@ function valueSearch(
   return match(value)
     .with(P.boolean, (value) => String(value).includes(search))
     .with(P.number, (value) => String(value).includes(search))
-    .with(P.string, (value) => value.includes(search))
+    .with(P.string, (value) => {
+      const newValue =
+        value === 'true' ? 'yes' : value === 'false' ? 'no' : value;
+
+      return newValue.includes(search);
+    })
     .with({}, (value) => JSON.stringify(value).includes(search))
     .otherwise(() => true);
 }


### PR DESCRIPTION
Do this can work ? I'm only checking if the value is true or false, to map this to "yes" or "no".