### PR TITLE
fix: remove targetProps where renderTarget is used

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,3 +1,9 @@
+import type {
+  AnchorButtonProps as BlueprintAnchorButtonProps,
+  ButtonProps as BlueprintButtonProps,
+  TagProps,
+  TooltipProps,
+} from '@blueprintjs/core';
 import {
   AnchorButton,
   Button as BlueprintButton,
@@ -5,12 +11,6 @@ import {
   Icon,
   Tag,
   Tooltip,
-} from '@blueprintjs/core';
-import type {
-  AnchorButtonProps as BlueprintAnchorButtonProps,
-  ButtonProps as BlueprintButtonProps,
-  TagProps,
-  TooltipProps,
 } from '@blueprintjs/core';
 import type { CSSObject } from '@emotion/styled';
 import styled from '@emotion/styled';
@@ -24,7 +24,7 @@ type BlueprintProps = {
 };
 
 export type ButtonProps = BlueprintProps & {
-  tooltipProps?: Partial<Omit<TooltipProps, 'children'>>;
+  tooltipProps?: Partial<Omit<TooltipProps, 'children' | 'targetProps'>>;
   tag?: ReactNode;
   tagProps?: Omit<TagProps, 'children'>;
 };

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -50,7 +50,8 @@ interface ToolbarItemInternalProps extends ToolbarItemProps {
   isPopover: boolean;
 }
 
-export interface ToolbarPopoverItemProps extends PopoverProps {
+export interface ToolbarPopoverItemProps
+  extends Omit<PopoverProps, 'targetProps'> {
   itemProps: ToolbarItemProps;
 }
 
@@ -251,13 +252,6 @@ Toolbar.PopoverItem = function ToolbarPopoverItem(
       interactionKind={popoverInteractionKind}
       hasBackdrop={popoverInteractionKind === 'click'}
       hoverCloseDelay={0}
-      targetProps={{
-        style: {
-          fontSize: '1.125em',
-          width: 'fit-content',
-          height: 'fit-content',
-        },
-      }}
       renderTarget={({ isOpen, className, ...targetProps }) => (
         <span {...targetProps} style={{ flex: '0 0 auto' }}>
           <ToolbarItemInternal isPopover {...itemProps} />


### PR DESCRIPTION
Blueprintjs prints a warning about the prop having no effect in that case.

Closes: https://github.com/zakodium-oss/react-science/issues/859
