### PR TITLE
fix: ensure content of split bar does not overflow

### DIFF
--- a/src/components/split-pane/SplitPane.tsx
+++ b/src/components/split-pane/SplitPane.tsx
@@ -211,17 +211,7 @@ function Splitter(props: SplitterProps) {
       direction={direction}
       ref={splitterRef}
     >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          placeContent: 'center',
-          fontSize: '0.875em',
-          maxHeight: '100%',
-        }}
-      >
-        {direction === 'horizontal' ? '⋮' : '⋯'}
-      </div>
+      <SplitContent>{direction === 'horizontal' ? '⋮' : '⋯'}</SplitContent>
     </Split>
   );
 }
@@ -321,4 +311,12 @@ const Split = styled.div<{
       `,
       )
       .exhaustive()}
+`;
+
+const SplitContent = styled.div`
+  display: flex;
+  align-items: center;
+  place-content: center;
+  font-size: 0.875em;
+  max-height: 100%;
 `;

--- a/src/components/split-pane/SplitPane.tsx
+++ b/src/components/split-pane/SplitPane.tsx
@@ -211,8 +211,16 @@ function Splitter(props: SplitterProps) {
       direction={direction}
       ref={splitterRef}
     >
-      <div style={{ fontSize: '0.875em' }}>
-        {direction === 'horizontal' ? <span>⋮</span> : <span>⋯</span>}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          placeContent: 'center',
+          fontSize: '0.875em',
+          maxHeight: '100%',
+        }}
+      >
+        {direction === 'horizontal' ? '⋮' : '⋯'}
       </div>
     </Split>
   );


### PR DESCRIPTION
Closes: https://github.com/zakodium-oss/react-science/issues/858
