### PR TITLE
feat(Table): allow to pass custom td attributes and reorder rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "14.0.0",
       "license": "MIT",
       "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^2.1.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
         "@emotion/styled": "^11.14.0",
         "@radix-ui/react-use-controllable-state": "^1.1.0",
         "@tanstack/react-table": "^8.21.2",
@@ -100,6 +103,37 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.5.0.tgz",
+      "integrity": "sha512-VnHcgOBALm+mbL9CoJPI6wBNQeB0is+CkejdfAlaP8RfBoELe+0sQtE8j4Z4fPRqDzo11OEqUYKHkmx4Ttzozg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "raf-schd": "^4.0.3"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-auto-scroll": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-auto-scroll/-/pragmatic-drag-and-drop-auto-scroll-2.1.0.tgz",
+      "integrity": "sha512-E52y8/0BTTf4ai6BJyFYgdVHFgQ1AES33KvAVQpZ41jMkoukLIq6UoCudOXku7xs3qoPygQdpC+vitVUuEFJXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-hitbox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.0.3.tgz",
+      "integrity": "sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.1.0",
+        "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4140,6 +4174,12 @@
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+      "license": "MIT"
     },
     "node_modules/biologic-converter": {
       "version": "0.6.0",
@@ -9108,6 +9148,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^2.1.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
     "@emotion/styled": "^11.14.0",
     "@radix-ui/react-use-controllable-state": "^1.1.0",
     "@tanstack/react-table": "^8.21.2",

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -1,2 +1,3 @@
 export * from './table_root.js';
 export * from './table_utils.js';
+export * from './reorder_rows/index.js';

--- a/src/components/table/reorder_rows/draggable_row_context.ts
+++ b/src/components/table/reorder_rows/draggable_row_context.ts
@@ -1,0 +1,23 @@
+import type { RefObject } from 'react';
+import { createContext, useContext } from 'react';
+
+import type { DraggableItemState } from './item_data.js';
+
+export interface DraggableRowContext {
+  state: DraggableItemState;
+  dragHandleRef: RefObject<HTMLButtonElement>;
+}
+
+export const draggableRowContext = createContext<DraggableRowContext | null>(
+  null,
+);
+
+export function useTableDraggableRowContext() {
+  const context = useContext(draggableRowContext);
+  if (!context) {
+    throw new Error(
+      'useDraggableItemContext must be used within an ItemContextProvider',
+    );
+  }
+  return context;
+}

--- a/src/components/table/reorder_rows/draggable_row_tr.tsx
+++ b/src/components/table/reorder_rows/draggable_row_tr.tsx
@@ -12,12 +12,14 @@ import {
 } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { Colors } from '@blueprintjs/core';
 import type { Row, RowData } from '@tanstack/react-table';
-import type { ReactNode } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { assert } from '../../utils/index.js';
-import type { TableRowTrProps } from '../table_utils.js';
+import type {
+  TableRowPreviewRenderer,
+  TableRowTrProps,
+} from '../table_utils.js';
 
 import type { DraggableRowContext } from './draggable_row_context.js';
 import { draggableRowContext } from './draggable_row_context.js';
@@ -27,9 +29,18 @@ import { getItemData, isItemData } from './item_data.js';
 import { useItemOrder } from './item_order_context.js';
 
 export interface TableDraggableRowTrProps<TData extends RowData> {
+  /**
+   * Props to be spread on the `tr` element.
+   */
   trProps: TableRowTrProps;
+  /**
+   * Row data.
+   */
   row: Row<TData>;
-  renderRowPreview: (row: Row<TData>) => ReactNode;
+  /**
+   * Preview of the row being dragged.
+   */
+  renderRowPreview: TableRowPreviewRenderer<TData>;
 }
 
 export function TableDraggableRowTr<TData extends RowData>(

--- a/src/components/table/reorder_rows/draggable_row_tr.tsx
+++ b/src/components/table/reorder_rows/draggable_row_tr.tsx
@@ -1,0 +1,155 @@
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import type { ElementDragPayload } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import {
+  draggable,
+  dropTargetForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { pointerOutsideOfPreview } from '@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview';
+import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { Colors } from '@blueprintjs/core';
+import type { Row, RowData } from '@tanstack/react-table';
+import type { ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { assert } from '../../utils/index.js';
+import type { TableRowTrProps } from '../table_utils.js';
+
+import type { DraggableRowContext } from './draggable_row_context.js';
+import { draggableRowContext } from './draggable_row_context.js';
+import { useDroppedItemContext } from './dropped_item_context.js';
+import type { DraggableItemState } from './item_data.js';
+import { getItemData, isItemData } from './item_data.js';
+import { useItemOrder } from './item_order_context.js';
+
+export interface TableDraggableRowTrProps<TData extends RowData> {
+  trProps: TableRowTrProps;
+  row: Row<TData>;
+  renderRowPreview: (row: Row<TData>) => ReactNode;
+}
+
+export function TableDraggableRowTr<TData extends RowData>(
+  props: TableDraggableRowTrProps<TData>,
+) {
+  const { trProps, row, renderRowPreview } = props;
+  const { instanceId } = useItemOrder();
+  const innerRef = useRef<HTMLTableRowElement>(null);
+  const [state, setState] = useState<DraggableItemState>(idleState);
+  const [droppedItemId, setDroppedItemId] = useDroppedItemContext();
+
+  const dragHandleRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    const trElement = innerRef.current;
+    assert(trElement, 'tr ref is null');
+    assert(dragHandleRef.current, 'dragHandleRef is null');
+
+    function canDrop({ source }: { source: ElementDragPayload }): boolean {
+      return (
+        isItemData(source.data) &&
+        source.data.instanceId === instanceId &&
+        source.data.id !== row.id
+      );
+    }
+
+    const data = getItemData(row as Row<unknown>, instanceId);
+
+    return combine(
+      draggable({
+        element: trElement,
+        dragHandle: dragHandleRef.current,
+        getInitialData: () => data,
+        onGenerateDragPreview({ nativeSetDragImage }) {
+          setCustomNativeDragPreview({
+            nativeSetDragImage,
+            getOffset: pointerOutsideOfPreview({
+              x: '8px',
+              y: '8px',
+            }),
+            render({ container }) {
+              setState({ type: 'preview', container });
+
+              return () => setState(draggingState);
+            },
+          });
+        },
+        onDragStart() {
+          setState(draggingState);
+        },
+        onDrop() {
+          setState(idleState);
+        },
+      }),
+      dropTargetForElements({
+        element: trElement,
+        canDrop,
+        getIsSticky: () => false,
+        getData({ input }) {
+          return attachClosestEdge(data, {
+            element: trElement,
+            input,
+            allowedEdges: ['top', 'bottom'],
+          });
+        },
+        onDrag({ self }) {
+          const closestEdge = extractClosestEdge(self.data);
+          setState((current) => {
+            if (
+              current.type === 'is-over' &&
+              current.closestEdge === closestEdge
+            ) {
+              return current;
+            }
+            return { type: 'is-over', closestEdge };
+          });
+        },
+        onDragLeave() {
+          setState(idleState);
+        },
+        onDrop() {
+          setState(idleState);
+        },
+      }),
+    );
+  }, [row, instanceId]);
+
+  useEffect(() => {
+    if (droppedItemId === row.id && innerRef.current) {
+      triggerPostFlash(innerRef.current);
+      setDroppedItemId(undefined);
+    }
+  }, [droppedItemId, row.id, setDroppedItemId]);
+
+  const value = useMemo<DraggableRowContext>(() => {
+    return {
+      dragHandleRef,
+      state,
+    };
+  }, [state]);
+
+  return (
+    <>
+      <draggableRowContext.Provider value={value}>
+        <tr {...trProps} ref={innerRef} />
+      </draggableRowContext.Provider>
+      {state.type === 'preview' &&
+        createPortal(renderRowPreview(row), state.container)}
+    </>
+  );
+}
+
+const idleState: DraggableItemState = { type: 'idle' };
+const draggingState: DraggableItemState = { type: 'dragging' };
+
+function triggerPostFlash(element: HTMLElement) {
+  element.animate(
+    [{ backgroundColor: Colors.BLUE5, opacity: 0.5 }, { opacity: 0.5 }],
+    {
+      duration: 250,
+      iterations: 1,
+    },
+  );
+}

--- a/src/components/table/reorder_rows/drop_indicator.tsx
+++ b/src/components/table/reorder_rows/drop_indicator.tsx
@@ -2,7 +2,20 @@ import type { Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/types';
 import { Colors } from '@blueprintjs/core';
 import styled from '@emotion/styled';
 
-export const TableDropIndicator = styled.div<{ edge: Edge }>`
+export interface TableDropIndicatorProps {
+  /**
+   * The edge (top or bottom) on which to render the drop indicator
+   * with respect to the nearest relatively positioned element.
+   */
+  edge: Edge;
+}
+
+/**
+ * An absolutely positioned line which indicates where a dragged item will
+ * be dropped.
+ *
+ */
+export const TableDropIndicator = styled.div<TableDropIndicatorProps>`
   position: absolute;
   z-index: 1;
   background-color: ${Colors.BLUE3};

--- a/src/components/table/reorder_rows/drop_indicator.tsx
+++ b/src/components/table/reorder_rows/drop_indicator.tsx
@@ -20,7 +20,9 @@ export const TableDropIndicator = styled.div<TableDropIndicatorProps>`
   z-index: 1;
   background-color: ${Colors.BLUE3};
   height: 2px;
-  inset: ${(props) =>
-    `${props.edge === 'top' ? '-1px' : 'initial'} 0 ${props.edge === 'bottom' ? '-1px' : 'initial'} 0`};
+  left: 0;
+  right: 0;
   pointer-events: none;
+  ${(props) => props.edge === 'top' && 'top: -1px;'}
+  ${(props) => props.edge === 'bottom' && 'bottom: -1px;'}
 `;

--- a/src/components/table/reorder_rows/drop_indicator.tsx
+++ b/src/components/table/reorder_rows/drop_indicator.tsx
@@ -1,0 +1,15 @@
+import type { Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/types';
+import { Colors } from '@blueprintjs/core';
+import styled from '@emotion/styled';
+
+export const TableDropIndicator = styled.div<{ edge: Edge }>`
+  position: absolute;
+  z-index: 1;
+  background-color: ${Colors.BLUE3};
+  height: 2px;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  bottom: ${(props) => (props.edge === 'bottom' ? '-1px' : 'inherit')};
+  top: ${(props) => (props.edge === 'top' ? '-1px' : 'inherit')};
+`;

--- a/src/components/table/reorder_rows/drop_indicator.tsx
+++ b/src/components/table/reorder_rows/drop_indicator.tsx
@@ -20,9 +20,7 @@ export const TableDropIndicator = styled.div<TableDropIndicatorProps>`
   z-index: 1;
   background-color: ${Colors.BLUE3};
   height: 2px;
-  left: 0;
-  right: 0;
+  inset: ${(props) =>
+    `${props.edge === 'top' ? '-1px' : 'initial'} 0 ${props.edge === 'bottom' ? '-1px' : 'initial'} 0`};
   pointer-events: none;
-  bottom: ${(props) => (props.edge === 'bottom' ? '-1px' : 'inherit')};
-  top: ${(props) => (props.edge === 'top' ? '-1px' : 'inherit')};
 `;

--- a/src/components/table/reorder_rows/dropped_item_context.ts
+++ b/src/components/table/reorder_rows/dropped_item_context.ts
@@ -1,0 +1,23 @@
+import type { useState } from 'react';
+import { createContext, useContext } from 'react';
+
+/**
+ * ID of the dropped item
+ */
+type DroppedItemContextValue = ReturnType<typeof useState<string>>;
+
+export const droppedItemContext = createContext<DroppedItemContextValue | null>(
+  null,
+);
+
+export function useDroppedItemContext() {
+  const context = useContext(droppedItemContext);
+
+  if (!context) {
+    throw new Error(
+      'useDroppedItemId must be used within a DroppedItemProvider',
+    );
+  }
+
+  return context;
+}

--- a/src/components/table/reorder_rows/dropped_item_provider.tsx
+++ b/src/components/table/reorder_rows/dropped_item_provider.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { droppedItemContext } from './dropped_item_context.js';
+
+export function DroppedItemProvider(props: { children: ReactNode }) {
+  const value = useState<string>();
+  return (
+    <droppedItemContext.Provider value={value}>
+      {props.children}
+    </droppedItemContext.Provider>
+  );
+}

--- a/src/components/table/reorder_rows/index.ts
+++ b/src/components/table/reorder_rows/index.ts
@@ -1,0 +1,4 @@
+export * from './table_drag_row_handler.js';
+export { useTableDraggableRowContext } from './draggable_row_context.js';
+export * from './draggable_row_tr.js';
+export * from './drop_indicator.js';

--- a/src/components/table/reorder_rows/item_data.ts
+++ b/src/components/table/reorder_rows/item_data.ts
@@ -1,0 +1,33 @@
+import type { Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/types';
+import type { Row } from '@tanstack/react-table';
+
+const itemKey = Symbol('table-item-data');
+export interface ItemData {
+  [itemKey]: true;
+  instanceId: symbol;
+  id: string;
+  index: number;
+  [key: string]: unknown;
+  [key: symbol]: unknown;
+}
+
+export function getItemData(row: Row<unknown>, instanceId: symbol): ItemData {
+  return {
+    [itemKey]: true,
+    id: row.id,
+    index: row.index,
+    instanceId,
+  };
+}
+
+export function isItemData(
+  data: Record<string | symbol, unknown>,
+): data is ItemData {
+  return data[itemKey] === true;
+}
+
+export type DraggableItemState =
+  | { type: 'idle' }
+  | { type: 'preview'; container: HTMLElement }
+  | { type: 'dragging' }
+  | { type: 'is-over'; closestEdge: Edge | null };

--- a/src/components/table/reorder_rows/item_order_context.ts
+++ b/src/components/table/reorder_rows/item_order_context.ts
@@ -1,0 +1,27 @@
+import type { Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/types';
+import type { Row } from '@tanstack/react-table';
+import { createContext, useContext } from 'react';
+
+export type ReorderItemCallback = (args: {
+  startIndex: number;
+  indexOfTarget: number;
+  closestEdgeOfTarget: Edge | null;
+}) => void;
+
+export interface ItemOrderContextValue<T = unknown> {
+  items: Array<Row<T>>;
+  reorderItem: ReorderItemCallback;
+  instanceId: symbol;
+}
+
+export const itemOrderContext = createContext<ItemOrderContextValue | null>(
+  null,
+);
+
+export function useItemOrder() {
+  const context = useContext(itemOrderContext);
+  if (!context) {
+    throw new Error('useItemOrder must be used within a ListContextProvider');
+  }
+  return context;
+}

--- a/src/components/table/reorder_rows/item_order_provider.tsx
+++ b/src/components/table/reorder_rows/item_order_provider.tsx
@@ -1,0 +1,61 @@
+import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
+import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
+import type { Row } from '@tanstack/react-table';
+import type { ReactNode } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+
+import type { ReorderItemCallback } from './item_order_context.js';
+import { itemOrderContext } from './item_order_context.js';
+
+interface ItemOrderProviderProps<T> {
+  items: Array<Row<T>>;
+  onOrderChanged: (items: Array<Row<T>>) => void;
+  children: ReactNode;
+}
+
+export function ItemOrderProvider<T = unknown>(
+  props: ItemOrderProviderProps<T>,
+) {
+  // Isolated instances of this component from one another
+  const [instanceId] = useState(() => Symbol('table-instance-id'));
+  const { items, onOrderChanged, children } = props;
+  const reorderItem = useCallback<ReorderItemCallback>(
+    ({ startIndex, indexOfTarget, closestEdgeOfTarget }) => {
+      const finishIndex = getReorderDestinationIndex({
+        startIndex,
+        closestEdgeOfTarget,
+        indexOfTarget,
+        axis: 'vertical',
+      });
+
+      if (finishIndex === startIndex) {
+        // If there is no change, we skip the update
+        return;
+      }
+
+      onOrderChanged(
+        reorder({
+          list: items,
+          startIndex,
+          finishIndex,
+        }),
+      );
+    },
+    [items, onOrderChanged],
+  );
+
+  const value = useMemo(
+    () => ({
+      reorderItem,
+      items: items as Array<Row<unknown>>,
+      instanceId,
+    }),
+    [reorderItem, items, instanceId],
+  );
+
+  return (
+    <itemOrderContext.Provider value={value}>
+      {children}
+    </itemOrderContext.Provider>
+  );
+}

--- a/src/components/table/reorder_rows/table_drag_row_handler.tsx
+++ b/src/components/table/reorder_rows/table_drag_row_handler.tsx
@@ -17,7 +17,6 @@ export function TableDragRowHandler() {
       {state?.type === 'is-over' && state.closestEdge && (
         <TableDropIndicator edge={state.closestEdge} />
       )}
-      <TableDropIndicator edge="bottom" />
     </>
   );
 }

--- a/src/components/table/reorder_rows/table_drag_row_handler.tsx
+++ b/src/components/table/reorder_rows/table_drag_row_handler.tsx
@@ -17,6 +17,7 @@ export function TableDragRowHandler() {
       {state?.type === 'is-over' && state.closestEdge && (
         <TableDropIndicator edge={state.closestEdge} />
       )}
+      <TableDropIndicator edge="bottom" />
     </>
   );
 }

--- a/src/components/table/reorder_rows/table_drag_row_handler.tsx
+++ b/src/components/table/reorder_rows/table_drag_row_handler.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@blueprintjs/core';
+
+import { useTableDraggableRowContext } from './draggable_row_context.js';
+import { TableDropIndicator } from './drop_indicator.js';
+
+export function TableDragRowHandler() {
+  const { dragHandleRef, state } = useTableDraggableRowContext();
+  return (
+    <>
+      <Button
+        icon="drag-handle-horizontal"
+        type="button"
+        ref={dragHandleRef}
+        variant="minimal"
+        style={{ cursor: 'grab' }}
+      />
+      {state?.type === 'is-over' && state.closestEdge && (
+        <TableDropIndicator edge={state.closestEdge} />
+      )}
+    </>
+  );
+}

--- a/src/components/table/reorder_rows/use_drop_monitor.ts
+++ b/src/components/table/reorder_rows/use_drop_monitor.ts
@@ -1,0 +1,74 @@
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import type { ElementDragPayload } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import type { RefObject } from 'react';
+import { useEffect } from 'react';
+
+import { assert } from '../../utils/index.js';
+
+import { useDroppedItemContext } from './dropped_item_context.js';
+import { isItemData } from './item_data.js';
+import { useItemOrder } from './item_order_context.js';
+
+/**
+ * Monitor drop events.
+ * Check if they can be acted on to reorder items.
+ * @param scrollElementRef The element to auto-scroll when dragging elements.
+ * @param enabled Enable or disable the monitoring.
+ */
+export function useDropMonitor(
+  scrollElementRef: RefObject<Element>,
+  enabled: boolean,
+) {
+  const { reorderItem, items } = useItemOrder();
+  const [, setDroppedItem] = useDroppedItemContext();
+  useEffect(() => {
+    const scrollContainer = scrollElementRef.current;
+    assert(scrollContainer, 'Missing scroll container ref');
+
+    if (enabled) {
+      function canRespond({ source }: { source: ElementDragPayload }) {
+        return isItemData(source.data);
+      }
+      return combine(
+        monitorForElements({
+          canMonitor: canRespond,
+          onDrop({ location, source }) {
+            const target = location.current.dropTargets[0];
+            if (!target) {
+              return;
+            }
+
+            const sourceData = source.data;
+            const targetData = target.data;
+            if (!isItemData(sourceData) || !isItemData(targetData)) {
+              return;
+            }
+
+            const indexOfTarget = items.findIndex(
+              (item) => item.id === targetData.id,
+            );
+            if (indexOfTarget === -1) {
+              return;
+            }
+
+            const closestEdgeOfTarget = extractClosestEdge(targetData);
+
+            reorderItem({
+              startIndex: sourceData.index,
+              indexOfTarget,
+              closestEdgeOfTarget,
+            });
+            setDroppedItem(sourceData.id);
+          },
+        }),
+        autoScrollForElements({
+          canScroll: canRespond,
+          element: scrollContainer,
+        }),
+      );
+    }
+  }, [items, reorderItem, scrollElementRef, setDroppedItem, enabled]);
+}

--- a/src/components/table/table_root.tsx
+++ b/src/components/table/table_root.tsx
@@ -124,8 +124,9 @@ interface TableBaseProps<TData extends RowData> {
   renderHeaderCell?: HeaderCellRenderer<TData>;
 
   /**
-   * Create custom props for cells in the table.
-   * The callback is called for each cell and contains the row's data.
+   * Pass custom props to the `<td>`.
+   * The callback is called for each cell and receives the row's data.
+   * The returned properties are spread onto the `<td>` element.
    */
   getTdProps?: GetTdProps<TData>;
 
@@ -136,21 +137,26 @@ interface TableBaseProps<TData extends RowData> {
   scrollToRowRef?: RefObject<VirtualScroller | ScrollToOptions | undefined>;
 
   /**
-   * An accessor which should a unique identifier for the row.
-   * Required when reordering rows is enabled via `onRowOrderChanged` prop.
+   * An accessor which should return a unique identifier for the row.
    */
   getRowId?: TableOptions<TData>['getRowId'];
 
   /**
    * Called when the user changed the order of the rows.
+   * Specifying this callback enables row reordering by drag and drop.
+   * Make sure to specify `getRowId` and not to use column sorting when you
+   * enable row reordering.
+   * Use the `TableDragRowHandler` component within table cells to provide the
+   * drag and drop interface for reordering rows.
    * @param rows The rows in their new order.
    */
   onRowOrderChanged?: (rows: TData[]) => void;
 
   /**
-   * Customize the preview of the row being dragged when reordering.
+   * Render function to customize the preview of the row being dragged
+   * when reordering.
+   * It receives the row being dragged.
    * Ignored when using custom row rendering with `renderRowTr`.
-   * @param row The row being dragged.
    */
   renderRowPreview?: TableRowPreviewRenderer<TData>;
 }
@@ -160,9 +166,10 @@ interface RegularTableProps<TData extends RowData>
   virtualizeRows?: false | undefined;
   scrollToRowRef?: RefObject<Scroller | undefined>;
   /**
-   * Specify a custom scrollable reference, which will be used to automatically
-   * scroll the table when reordering elements.
-   * By default, the table itself is used as the scrollable element.
+   * Specify a custom scrollable reference, which will be used to
+   * automatically scroll the table when reordering elements.
+   * By default, the table itself is used as the scrollable element, but
+   * you must style it to make it scrollable.
    */
   scrollableElementRef?: RefObject<Element>;
 }

--- a/src/components/table/table_root.tsx
+++ b/src/components/table/table_root.tsx
@@ -1,6 +1,6 @@
 import { HTMLTable } from '@blueprintjs/core';
 import styled from '@emotion/styled';
-import type { RowData, TableOptions } from '@tanstack/react-table';
+import type { Header, RowData, TableOptions } from '@tanstack/react-table';
 import {
   getCoreRowModel,
   getSortedRowModel,
@@ -8,14 +8,19 @@ import {
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { ReactNode, RefObject, TableHTMLAttributes } from 'react';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
+import { DroppedItemProvider } from './reorder_rows/dropped_item_provider.js';
+import { ItemOrderProvider } from './reorder_rows/item_order_provider.js';
+import { useDropMonitor } from './reorder_rows/use_drop_monitor.js';
 import { TableBody } from './table_body.js';
 import { TableHeader } from './table_header.js';
 import type { HeaderCellRenderer } from './table_header_cell.js';
 import type {
+  GetTdProps,
   Scroller,
   TableColumnDef,
+  TableRowPreviewRenderer,
   TableRowTrRenderer,
   VirtualScroller,
 } from './table_utils.js';
@@ -57,6 +62,9 @@ const CustomHTMLTable = styled(HTMLTable, {
 `;
 
 interface TableBaseProps<TData extends RowData> {
+  /**
+   * The original data to display in the table.
+   */
   data: TData[];
   /**
    * Tanstack table definition of columns in the table.
@@ -116,18 +124,47 @@ interface TableBaseProps<TData extends RowData> {
   renderHeaderCell?: HeaderCellRenderer<TData>;
 
   /**
+   * Create custom props for cells in the table.
+   * The callback is called for each cell and contains the row's data.
+   */
+  getTdProps?: GetTdProps<TData>;
+
+  /**
    * A ref which will be set with a callback to scroll to a row in the
    * table, specified by the row's ID.
    */
   scrollToRowRef?: RefObject<VirtualScroller | ScrollToOptions | undefined>;
 
+  /**
+   * An accessor which should a unique identifier for the row.
+   * Required when reordering rows is enabled via `onRowOrderChanged` prop.
+   */
   getRowId?: TableOptions<TData>['getRowId'];
+
+  /**
+   * Called when the user changed the order of the rows.
+   * @param rows The rows in their new order.
+   */
+  onRowOrderChanged?: (rows: TData[]) => void;
+
+  /**
+   * Customize the preview of the row being dragged when reordering.
+   * Ignored when using custom row rendering with `renderRowTr`.
+   * @param row The row being dragged.
+   */
+  renderRowPreview?: TableRowPreviewRenderer<TData>;
 }
 
 interface RegularTableProps<TData extends RowData>
   extends TableBaseProps<TData> {
   virtualizeRows?: false | undefined;
   scrollToRowRef?: RefObject<Scroller | undefined>;
+  /**
+   * Specify a custom scrollable reference, which will be used to automatically
+   * scroll the table when reordering elements.
+   * By default, the table itself is used as the scrollable element.
+   */
+  scrollableElementRef?: RefObject<Element>;
 }
 
 interface VirtualizedTableProps<TData extends RowData>
@@ -162,11 +199,14 @@ export function Table<TData extends RowData>(props: TableProps<TData>) {
     className,
     renderRowTr,
     renderHeaderCell,
+    getTdProps,
 
     virtualizeRows,
     getRowId,
+    onRowOrderChanged,
+    renderRowPreview,
   } = props;
-
+  const isReorderingEnabled = !!onRowOrderChanged;
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const columnDefs = useTableColumns(columns);
   const table = useReactTable<TData>({
@@ -199,31 +239,56 @@ export function Table<TData extends RowData>(props: TableProps<TData>) {
     finalClassName = tableProps?.className;
   }
 
+  const tableHeaders = table.getFlatHeaders();
+  useCheckProps(
+    props as TableProps<unknown>,
+    tableHeaders as Array<Header<unknown, unknown>>,
+  );
   return (
-    <Container virtualizeRows={virtualizeRows} scrollRef={scrollElementRef}>
-      <CustomHTMLTable
-        ref={tableRef}
-        bordered={bordered}
-        compact={compact}
-        interactive={interactive}
-        striped={striped}
-        stickyHeader={stickyHeader}
-        {...tableProps}
-        className={finalClassName}
+    <DroppedItemProvider>
+      <ItemOrderProvider
+        items={table.getRowModel().rows}
+        onOrderChanged={(items) => {
+          onRowOrderChanged?.(items.map((item) => item.original));
+        }}
       >
-        <TableHeader
-          sticky={stickyHeader}
-          headers={table.getFlatHeaders()}
-          renderHeaderCell={renderHeaderCell}
-        />
-        <TableBody
-          rows={table.getRowModel().rows}
-          renderRowTr={renderRowTr}
-          virtualizer={tanstackVirtualizer}
+        <Container
           virtualizeRows={virtualizeRows}
-        />
-      </CustomHTMLTable>
-    </Container>
+          scrollRef={
+            virtualizeRows
+              ? scrollElementRef
+              : props.scrollableElementRef || tableRef
+          }
+          isReorderingEnabled={isReorderingEnabled}
+        >
+          <CustomHTMLTable
+            ref={tableRef}
+            bordered={bordered}
+            compact={compact}
+            interactive={interactive}
+            striped={striped}
+            stickyHeader={stickyHeader}
+            {...tableProps}
+            className={finalClassName}
+          >
+            <TableHeader
+              sticky={stickyHeader}
+              headers={tableHeaders}
+              renderHeaderCell={renderHeaderCell}
+            />
+            <TableBody
+              rows={table.getRowModel().rows}
+              renderRowTr={renderRowTr}
+              getTdProps={getTdProps}
+              virtualizer={tanstackVirtualizer}
+              virtualizeRows={virtualizeRows}
+              renderRowPreview={renderRowPreview}
+              isReorderingEnabled={isReorderingEnabled}
+            />
+          </CustomHTMLTable>
+        </Container>
+      </ItemOrderProvider>
+    </DroppedItemProvider>
   );
 }
 
@@ -232,17 +297,77 @@ const ScrollRefDiv = styled.div`
   overflow: auto;
 `;
 
-function Container({
-  virtualizeRows,
-  scrollRef,
-  children,
-}: {
+interface ContainerProps {
   virtualizeRows?: boolean;
   children: ReactNode;
-  scrollRef: RefObject<HTMLDivElement>;
-}) {
+  scrollRef: RefObject<Element>;
+  isReorderingEnabled: boolean;
+}
+
+function Container(props: ContainerProps) {
+  const { virtualizeRows, scrollRef, isReorderingEnabled, children } = props;
   if (virtualizeRows) {
-    return <ScrollRefDiv ref={scrollRef}>{children}</ScrollRefDiv>;
+    return (
+      <ContainerVirtual
+        scrollElementRef={scrollRef}
+        enabled={isReorderingEnabled}
+      >
+        {children}
+      </ContainerVirtual>
+    );
   }
+  return (
+    <ContainerTable scrollElementRef={scrollRef} enabled={isReorderingEnabled}>
+      {children}
+    </ContainerTable>
+  );
+}
+
+interface ContainerWithReorderingProps {
+  scrollElementRef: RefObject<Element>;
+  enabled: boolean;
+  children: ReactNode;
+}
+
+function ContainerVirtual(props: ContainerWithReorderingProps) {
+  const { scrollElementRef, enabled, children } = props;
+  useDropMonitor(scrollElementRef, enabled);
+
+  return (
+    <ScrollRefDiv ref={scrollElementRef as RefObject<HTMLDivElement>}>
+      {children}
+    </ScrollRefDiv>
+  );
+}
+
+interface ContainerTableProps {
+  scrollElementRef: RefObject<Element>;
+  enabled: boolean;
+  children: ReactNode;
+}
+function ContainerTable(props: ContainerTableProps) {
+  const { scrollElementRef, enabled, children } = props;
+  useDropMonitor(scrollElementRef, enabled);
   return <>{children}</>;
+}
+
+function useCheckProps(
+  props: TableProps<unknown>,
+  headers: Array<Header<unknown, unknown>>,
+) {
+  const { onRowOrderChanged, getRowId } = props;
+  useEffect(() => {
+    if (onRowOrderChanged && !getRowId) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'When reordering rows is enabled via the `onRowOrderChanged` prop, the `getRowId` prop must be provided to identify each row unambiguously.',
+      );
+    }
+    if (headers.some((header) => header.column.getCanSort())) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'When reordering rows is enabled via the `onRowOrderChanged` prop, none of the columns should be sortable as data order will be overriden by internal sorting.',
+      );
+    }
+  }, [onRowOrderChanged, getRowId, headers]);
 }

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -1,18 +1,20 @@
 import type { Cell, RowData } from '@tanstack/react-table';
 import { flexRender } from '@tanstack/react-table';
 
+import type { GetTdProps } from './table_utils.js';
+
 interface TableRowCellProps<TData extends RowData> {
   cell: Cell<TData, unknown>;
-  className?: string;
+  getTdProps: GetTdProps<TData> | undefined;
 }
 
 export function TableRowCell<TData extends RowData>(
   props: TableRowCellProps<TData>,
 ) {
-  const { cell, className } = props;
+  const { cell, getTdProps } = props;
 
   return (
-    <td style={{ position: 'relative' }} className={className}>
+    <td {...getTdProps?.(cell)}>
       {flexRender(cell.column.columnDef.cell, cell.getContext())}
     </td>
   );

--- a/src/components/table/table_utils.ts
+++ b/src/components/table/table_utils.ts
@@ -1,12 +1,18 @@
-import type { ColumnDef, Row, RowData } from '@tanstack/react-table';
+import type { Cell, ColumnDef, Row, RowData } from '@tanstack/react-table';
 import { createColumnHelper } from '@tanstack/react-table';
 import type { ScrollToOptions } from '@tanstack/react-virtual';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode, TdHTMLAttributes } from 'react';
 
 export type TableColumnDef<TData extends RowData, TValue = unknown> = ColumnDef<
   TData,
   TValue
 >;
+
+type TableTdProps = TdHTMLAttributes<HTMLTableCellElement>;
+
+export type GetTdProps<TData extends RowData> = (
+  cell: Cell<TData, unknown>,
+) => TableTdProps;
 
 export function createTableColumnHelper<TData extends RowData>() {
   return createColumnHelper<TData>();
@@ -14,6 +20,7 @@ export function createTableColumnHelper<TData extends RowData>() {
 
 export interface TableRowTrProps {
   className: string;
+  style: CSSProperties;
   children: ReactNode;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'data-row-id': string;
@@ -21,6 +28,10 @@ export interface TableRowTrProps {
 
 export type TableRowTrRenderer<TData extends RowData> = (
   trProps: TableRowTrProps,
+  row: Row<TData>,
+) => ReactNode;
+
+export type TableRowPreviewRenderer<TData extends RowData> = (
   row: Row<TData>,
 ) => ReactNode;
 

--- a/src/components/table/table_utils.ts
+++ b/src/components/table/table_utils.ts
@@ -32,6 +32,9 @@ export type TableRowTrRenderer<TData extends RowData> = (
 ) => ReactNode;
 
 export type TableRowPreviewRenderer<TData extends RowData> = (
+  /**
+   * The row being dragged, for which to render a preview.
+   */
   row: Row<TData>,
 ) => ReactNode;
 

--- a/stories/components/table.reorder.stories.tsx
+++ b/stories/components/table.reorder.stories.tsx
@@ -1,0 +1,146 @@
+import { Tag } from '@blueprintjs/core';
+import { action } from '@storybook/addon-actions';
+import { useRef, useState } from 'react';
+import { IdcodeSvgRenderer } from 'react-ocl';
+
+import type { GetTdProps, TableProps } from '../../src/components/index.js';
+import {
+  createTableColumnHelper,
+  Table,
+  TableDraggableRowTr,
+  TableDragRowHandler,
+} from '../../src/components/index.js';
+import { table } from '../data/data.js';
+
+type ControlProps = Pick<
+  TableProps<TableRecord>,
+  | 'bordered'
+  | 'compact'
+  | 'interactive'
+  | 'striped'
+  | 'stickyHeader'
+  | 'virtualizeRows'
+  | 'getTdProps'
+>;
+
+type TableRecord = (typeof table)[number];
+
+const getTdProps: GetTdProps<TableRecord> = () => ({
+  style: {
+    verticalAlign: 'middle',
+  },
+});
+
+const getRowId: TableProps<TableRecord>['getRowId'] = (row) => row.id;
+
+export default {
+  title: 'Components / Table / Reordering rows',
+  component: Table,
+  args: {
+    bordered: true,
+    compact: false,
+    interactive: false,
+    striped: false,
+    stickyHeader: false,
+    getTdProps,
+    getRowId,
+  },
+};
+
+const columnHelper = createTableColumnHelper<(typeof table)[number]>();
+
+const columns = [
+  columnHelper.display({
+    header: 'Drag',
+    cell: () => <TableDragRowHandler />,
+  }),
+  columnHelper.accessor('ocl.idCode', {
+    header: 'Molecule',
+    cell: ({ getValue }) => <IdcodeSvgRenderer idcode={getValue()} />,
+    meta: { color: 'yellow', width: 400 },
+  }),
+  columnHelper.accessor('name', {
+    header: 'Name',
+    cell: ({ getValue }) => getValue(),
+  }),
+];
+
+export function ReordableRows(props: ControlProps) {
+  const [data, setData] = useState(table);
+  const scrollableRef = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={scrollableRef}
+      style={{ padding: 12, height: '100%', overflowY: 'auto' }}
+    >
+      <Table<TableRecord>
+        data={data}
+        columns={columns}
+        estimatedRowHeight={() => 172}
+        scrollableElementRef={scrollableRef}
+        onRowOrderChanged={(rows) => {
+          setData(rows);
+          action('onRowOrderChanged')(rows);
+        }}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export function WithCustomPreview(props: ControlProps) {
+  const [data, setData] = useState(table);
+  const scrollableRef = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={scrollableRef}
+      style={{ padding: 12, height: '100%', overflowY: 'auto' }}
+    >
+      <Table<TableRecord>
+        data={data}
+        columns={columns}
+        estimatedRowHeight={() => 172}
+        renderRowPreview={(row) => <Tag>{row.original.name}</Tag>}
+        scrollableElementRef={scrollableRef}
+        onRowOrderChanged={(rows) => {
+          setData(rows);
+          action('onRowOrderChanged')(rows);
+        }}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export function WithCustomRowRendering(props: ControlProps) {
+  const [data, setData] = useState(table);
+  const scrollableRef = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={scrollableRef}
+      style={{ padding: 12, height: '100%', overflowY: 'auto' }}
+    >
+      <Table<TableRecord>
+        data={data}
+        columns={columns}
+        estimatedRowHeight={() => 172}
+        renderRowTr={(trProps, row) => (
+          <TableDraggableRowTr
+            trProps={{
+              ...trProps,
+              style: { ...trProps.style, backgroundColor: row.original.color },
+            }}
+            row={row}
+            renderRowPreview={(row) => <Tag>{row.original.name}</Tag>}
+          />
+        )}
+        scrollableElementRef={scrollableRef}
+        onRowOrderChanged={(rows) => {
+          setData(rows);
+          action('onRowOrderChanged')(rows);
+        }}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/stories/components/table.stories.tsx
+++ b/stories/components/table.stories.tsx
@@ -5,7 +5,12 @@ import type { ComponentType } from 'react';
 import { useRef, useState } from 'react';
 import { IdcodeSvgRenderer } from 'react-ocl';
 
-import type { Scroller, VirtualScroller } from '../../src/components/index.js';
+import type {
+  GetTdProps,
+  Scroller,
+  TableProps,
+  VirtualScroller,
+} from '../../src/components/index.js';
 import {
   createTableColumnHelper,
   Table,
@@ -15,17 +20,26 @@ import { table } from '../data/data.js';
 
 type TableRecord = (typeof table)[number];
 
-interface ControlProps {
-  bordered?: boolean;
-  compact?: boolean;
-  interactive?: boolean;
-  striped?: boolean;
-  stickyHeader?: boolean;
-  virtualizeRows?: boolean;
-}
+const getTdProps: GetTdProps<TableRecord> = () => ({
+  style: {
+    verticalAlign: 'middle',
+  },
+});
+
+type ControlProps = Pick<
+  TableProps<TableRecord>,
+  | 'bordered'
+  | 'compact'
+  | 'interactive'
+  | 'striped'
+  | 'stickyHeader'
+  | 'virtualizeRows'
+  | 'getTdProps'
+>;
 
 export default {
   title: 'Components / Table',
+  component: Table,
   decorators: [
     (Story: ComponentType) => (
       <div style={{ margin: 12, height: '100%', overflowY: 'auto' }}>
@@ -40,6 +54,7 @@ export default {
     interactive: false,
     striped: false,
     stickyHeader: false,
+    getTdProps,
   },
 };
 
@@ -91,43 +106,21 @@ const columns = [
   columnHelper.accessor('color', { header: 'Color' }),
 ];
 
-export function Control({
-  bordered,
-  compact,
-  interactive,
-  striped,
-  stickyHeader,
-  virtualizeRows,
-}: ControlProps) {
+export function Control(props: ControlProps) {
   return (
     <Table
-      bordered={bordered}
-      compact={compact}
-      interactive={interactive}
-      striped={striped}
-      stickyHeader={stickyHeader}
+      {...props}
       columns={columns}
-      virtualizeRows={virtualizeRows}
       estimatedRowHeight={() => 172}
       data={table}
     />
   );
 }
 
-export function CustomTrRender({
-  bordered,
-  compact,
-  interactive,
-  striped,
-  stickyHeader,
-}: ControlProps) {
+export function CustomTrRender(props: ControlProps) {
   return (
     <Table
-      bordered={bordered}
-      compact={compact}
-      interactive={interactive}
-      striped={striped}
-      stickyHeader={stickyHeader}
+      {...props}
       columns={columns}
       data={table}
       virtualizeRows
@@ -139,21 +132,10 @@ export function CustomTrRender({
   );
 }
 
-export function CustomHeaderCellRender({
-  bordered,
-  compact,
-  interactive,
-  striped,
-  stickyHeader,
-  virtualizeRows,
-}: ControlProps) {
+export function CustomHeaderCellRender(props: ControlProps) {
   return (
     <Table
-      bordered={bordered}
-      compact={compact}
-      interactive={interactive}
-      striped={striped}
-      stickyHeader={stickyHeader}
+      {...props}
       columns={columns}
       data={table}
       tableProps={{
@@ -162,7 +144,6 @@ export function CustomHeaderCellRender({
           width: '100%',
         },
       }}
-      virtualizeRows={virtualizeRows}
       estimatedRowHeight={() => 172}
       renderHeaderCell={(thProps, header) => {
         const backgroundColor = header.column.columnDef.meta?.color;
@@ -307,7 +288,7 @@ export const ScrollRowIntoView = {
 function useScrollButtons(onIndexChanged: (index: number) => void) {
   const [rowIndex, setRowIndex] = useState(0);
 
-  const buttons = (
+  return (
     <Callout title="Scroll to row">
       <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
         <div>Last: {table[rowIndex].name}</div>
@@ -343,5 +324,4 @@ function useScrollButtons(onIndexChanged: (index: number) => void) {
       </div>
     </Callout>
   );
-  return buttons;
 }


### PR DESCRIPTION
- Add `getTdProps` prop which allows to customize the attributes passed to the `<td>` elements, including style. This is useful for example to center content within a cell as this can not easily be done in tables based on the cell's children only.
- Add `onRowOrderChanged` callback which is called when a manual reordering operation is finished, with the data items in their new order.
- Add `renderRowPreview` to customize the content of the dragged row's preview.
- Add `scrollableElementRef` prop which allows to pass an external reference to the element that should be auto-scrolled when reordering rows.
- Export new `TableDragRowHandler` for a good default drag handler that can be used in cell renderers.

Other new hooks and components which allow to customize the row reordering UI:
- `useTableDraggableRowContext` and `TableDropIndicator` for implementing your own drag handler instead of `TableDragRowHandler`.
- `TableDraggableRowTr` component which can be used in custom row rendering with support of row reordering.

When the reordering callback is used, there is a warning if:
- some columns are sortable as sorting is incompatible with reordering
- `getRowId` is not specified, since rows must have stable identifiers during reordering.

There was some research on different library candidates: https://github.com/zakodium-oss/react-science/issues/868#issuecomment-2688261956
The atlaskit library was retained because of support from a big company + it being lightweight.

BREAKING CHANGE: td cells no longer have `position: relative;` by default but this can be overridden using `getTdProps`.

Closes: https://github.com/zakodium-oss/react-science/issues/868
