### PR TITLE
feat: change FullScreenProvider API to not create additional div

### DIFF
--- a/src/components/fullscreen/fullscreen_context.provider.tsx
+++ b/src/components/fullscreen/fullscreen_context.provider.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-alert */
-import type { ReactNode } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
 
 import { fullscreenContext, useFullscreen } from './fullscreen_context.js';
@@ -13,7 +13,11 @@ type DocumentType = Document & {
   webkitFullscreenElement: Element | null;
 };
 interface FullscreenProps {
-  children: ReactNode;
+  /**
+   * Callback providing the ref which should be passed to the element that can be displayed fullscreen.
+   * @param ref
+   */
+  children: (ref: RefObject<HTMLDivElement>) => ReactNode;
 }
 
 export function FullScreenProvider(props: FullscreenProps) {
@@ -78,16 +82,5 @@ function FullscreenInner(props: FullscreenProps) {
       }
     }
   }, [isFullScreen]);
-  return (
-    <div
-      ref={ref}
-      style={{
-        width: '100%',
-        height: '100%',
-        backgroundColor: 'white',
-      }}
-    >
-      {children}
-    </div>
-  );
+  return children(ref);
 }

--- a/src/components/root-layout/css-reset/customPreflight.ts
+++ b/src/components/root-layout/css-reset/customPreflight.ts
@@ -24,4 +24,10 @@ export const CustomDivPreflight = styled.div`
   width: 100%;
   height: 100%;
   position: relative;
+
+  &:fullscreen::backdrop,
+  *:fullscreen::backdrop {
+    /* Override user agent default */
+    background-color: white;
+  }
 `;

--- a/src/components/root-layout/root_layout.tsx
+++ b/src/components/root-layout/root_layout.tsx
@@ -1,8 +1,9 @@
 import { BlueprintProvider, FocusStyleManager } from '@blueprintjs/core';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, MutableRefObject, ReactNode } from 'react';
 import { useCallback, useState } from 'react';
 
 import { AccordionProvider } from '../accordion/index.js';
+import { FullScreenProvider } from '../fullscreen/index.js';
 
 import { CustomDivPreflight } from './css-reset/customPreflight.js';
 import { RootLayoutProvider } from './root_layout_context.provider.js';
@@ -27,28 +28,39 @@ export function RootLayout(props: RootLayoutProps) {
     typeof document !== 'undefined' ? document.body : null,
   );
 
-  const ref = useCallback((node: HTMLDivElement) => {
+  const refCallback = useCallback((node: HTMLDivElement) => {
     if (node !== null) {
       setRootRef(node);
     }
   }, []);
 
   return (
-    <CustomDivPreflight
-      ref={ref}
-      style={{
-        ...style,
-        ...props.style,
-      }}
-      translate="no"
-    >
-      <BlueprintProvider
-        {...(rootRef ? { portalContainer: rootRef } : undefined)}
-      >
-        <RootLayoutProvider innerRef={rootRef}>
-          <AccordionProvider>{props.children}</AccordionProvider>
-        </RootLayoutProvider>
-      </BlueprintProvider>
-    </CustomDivPreflight>
+    <FullScreenProvider>
+      {(ref) => (
+        <CustomDivPreflight
+          id="root-layout"
+          ref={(node) => {
+            if (node) {
+              const mutableRef = ref as MutableRefObject<HTMLDivElement>;
+              mutableRef.current = node;
+              refCallback(node);
+            }
+          }}
+          style={{
+            ...style,
+            ...props.style,
+          }}
+          translate="no"
+        >
+          <BlueprintProvider
+            {...(rootRef ? { portalContainer: rootRef } : undefined)}
+          >
+            <RootLayoutProvider innerRef={rootRef}>
+              <AccordionProvider>{props.children}</AccordionProvider>
+            </RootLayoutProvider>
+          </BlueprintProvider>
+        </CustomDivPreflight>
+      )}
+    </FullScreenProvider>
   );
 }

--- a/src/pages/demo/App.tsx
+++ b/src/pages/demo/App.tsx
@@ -3,11 +3,7 @@ import { FifoLogger } from 'fifo-logger';
 import { KbsProvider } from 'react-kbs';
 
 import { AppStateProvider } from '../../app-data/index.js';
-import {
-  FifoLoggerProvider,
-  FullScreenProvider,
-  RootLayout,
-} from '../../components/index.js';
+import { FifoLoggerProvider, RootLayout } from '../../components/index.js';
 
 import MainLayout from './MainLayout.js';
 import { queryClient } from './query_client.js';
@@ -21,17 +17,15 @@ const fifoLogger = new FifoLogger({ level: 'debug' });
 export default function App() {
   return (
     <FifoLoggerProvider logger={fifoLogger}>
-      <FullScreenProvider>
-        <RootLayout>
-          <QueryClientProvider client={queryClient}>
-            <KbsProvider>
-              <AppStateProvider>
-                <MainLayout />
-              </AppStateProvider>
-            </KbsProvider>
-          </QueryClientProvider>
-        </RootLayout>
-      </FullScreenProvider>
+      <RootLayout>
+        <QueryClientProvider client={queryClient}>
+          <KbsProvider>
+            <AppStateProvider>
+              <MainLayout />
+            </AppStateProvider>
+          </KbsProvider>
+        </QueryClientProvider>
+      </RootLayout>
     </FifoLoggerProvider>
   );
 }

--- a/stories/components/fullscreen.stories.tsx
+++ b/stories/components/fullscreen.stories.tsx
@@ -1,3 +1,6 @@
+import styled from '@emotion/styled';
+import type { CSSProperties, ReactNode } from 'react';
+
 import {
   Button,
   FullScreenProvider,
@@ -10,42 +13,52 @@ export default {
 
 export function Basic() {
   return (
-    <div>
-      <FullScreenProvider>
-        <div
-          style={{ border: 'solid 1px black', padding: '10px', margin: '10px' }}
-        >
-          Page 1
-          <FullScreenProvider>
-            <div
-              style={{
-                border: 'solid 1px red',
-                padding: '10px',
-                margin: '10px',
-              }}
-            >
-              Page 2
-              <FullScreenProvider>
-                <div
-                  style={{
-                    border: 'solid 1px blue',
-                    padding: '10px',
-                    margin: '10px',
-                  }}
-                >
-                  Page 3
-                  <Content i="3" />
-                </div>
-              </FullScreenProvider>
-              <Content i="2" />
-            </div>
-          </FullScreenProvider>
-          <Content i="1" />
-        </div>
-      </FullScreenProvider>
-    </div>
+    <FullScreenProvider>
+      {(page1) => (
+        <FullPageRoot ref={page1} color="green">
+          <FullPageContent i="1">
+            <FullScreenProvider>
+              {(page2) => (
+                <FullPageRoot ref={page2} color="red">
+                  <FullPageContent i="2">
+                    <FullScreenProvider>
+                      {(page3) => (
+                        <FullPageRoot color="blue" ref={page3}>
+                          <FullPageContent i="3" />
+                        </FullPageRoot>
+                      )}
+                    </FullScreenProvider>
+                  </FullPageContent>
+                </FullPageRoot>
+              )}
+            </FullScreenProvider>
+          </FullPageContent>
+        </FullPageRoot>
+      )}
+    </FullScreenProvider>
   );
 }
+
+const FullPageRoot = styled.div<{ color: CSSProperties['borderColor'] }>`
+  border: 2px solid ${(props) => props.color};
+`;
+
+function FullPageContent({ i, children }: { i: string; children?: ReactNode }) {
+  return (
+    <FullPageInner>
+      Page {i}
+      {children}
+      <Content i={i} />
+    </FullPageInner>
+  );
+}
+
+const FullPageInner = styled.div`
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
 
 function Content({ i }: { i: string }) {
   const { toggle } = useFullscreen();


### PR DESCRIPTION
BREAKING-CHANGE: FullScreenProvider now takes a render callback with the ref to attach to the element which can be displayed fullscreen. It no longer renders an additional styled div.
The RootLayout is now a fullscreenable element. It is no longer necessary to wrap it in a FullScreenProvider. Added a global CSS rule to make fullscreen elements' backdrop background color white.

Closes: https://github.com/zakodium-oss/react-science/issues/689

Note: It is not possible to add a margin to a fullscreen element so the stories are slightly different now.

I find it to make more sense to put the border on the element which is fullscreenable rather than a child of it.
Therefore there is no space outside the border anymore.