### PR TITLE
fix: make sure build is natively compatible with ESM

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,7 +2,7 @@
   "extends": ["stylelint-config-standard"],
   "overrides": [
     {
-      "files": ["*.{js,jsx,ts,tsx}"],
+      "files": ["*.{js,jsx,ts,tsx,cts}"],
       "customSyntax": "postcss-styled-syntax"
     }
   ]

--- a/src/components/pdnd.cts
+++ b/src/components/pdnd.cts
@@ -1,3 +1,6 @@
+// Given how @atlaskit/pragmatic-drag-and-drop publishes ESM in a non-native way,
+// we have to trick TS into using the CJS build so that our build is compatible
+// with native ESM.
 export { pointerOutsideOfPreview } from '@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview';
 export { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
 export { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';

--- a/src/components/pdnd.cts
+++ b/src/components/pdnd.cts
@@ -1,0 +1,15 @@
+export { pointerOutsideOfPreview } from '@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview';
+export { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
+export { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+export { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
+export {
+  draggable,
+  dropTargetForElements,
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+export { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+export { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+export {
+  extractClosestEdge,
+  attachClosestEdge,
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+export { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';

--- a/src/components/pdnd.cts
+++ b/src/components/pdnd.cts
@@ -1,3 +1,4 @@
+// https://github.com/atlassian/pragmatic-drag-and-drop/issues/27
 // Given how @atlaskit/pragmatic-drag-and-drop publishes ESM in a non-native way,
 // we have to trick TS into using the CJS build so that our build is compatible
 // with native ESM.

--- a/src/components/pdnd.cts
+++ b/src/components/pdnd.cts
@@ -1,7 +1,8 @@
 // https://github.com/atlassian/pragmatic-drag-and-drop/issues/27
-// Given how @atlaskit/pragmatic-drag-and-drop publishes ESM in a non-native way,
+// Given how `@atlaskit/pragmatic-drag-and-drop` publishes ESM in a non-native way,
 // we have to trick TS into using the CJS build so that our build is compatible
 // with native ESM.
+// We cannot use `verbatimModuleSyntax` ts config option with this pattern.
 export { pointerOutsideOfPreview } from '@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview';
 export { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
 export { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';

--- a/src/components/table/reorder_rows/draggable_row_tr.tsx
+++ b/src/components/table/reorder_rows/draggable_row_tr.tsx
@@ -1,19 +1,17 @@
-import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
 import type { ElementDragPayload } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import {
-  draggable,
-  dropTargetForElements,
-} from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import { pointerOutsideOfPreview } from '@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview';
-import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview';
-import {
-  attachClosestEdge,
-  extractClosestEdge,
-} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import type { Row, RowData } from '@tanstack/react-table';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import {
+  attachClosestEdge,
+  combine,
+  draggable,
+  dropTargetForElements,
+  extractClosestEdge,
+  pointerOutsideOfPreview,
+  setCustomNativeDragPreview,
+} from '../../pdnd.cjs';
 import { assert } from '../../utils/index.js';
 import { useFlashRowEffect } from '../flash_row/use_flash_row_effect.js';
 import { PreviewTable } from '../preview_table.js';

--- a/src/components/table/reorder_rows/item_order_provider.tsx
+++ b/src/components/table/reorder_rows/item_order_provider.tsx
@@ -1,8 +1,8 @@
-import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
-import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
 import type { Row } from '@tanstack/react-table';
 import type { ReactNode } from 'react';
 import { useCallback, useMemo, useState } from 'react';
+
+import { getReorderDestinationIndex, reorder } from '../../pdnd.cjs';
 
 import type { ReorderItemCallback } from './item_order_context.js';
 import { itemOrderContext } from './item_order_context.js';

--- a/src/components/table/reorder_rows/use_drop_monitor.ts
+++ b/src/components/table/reorder_rows/use_drop_monitor.ts
@@ -1,11 +1,13 @@
-import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
 import type { ElementDragPayload } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
-import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
-import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import type { RefObject } from 'react';
 import { useEffect } from 'react';
 
+import {
+  autoScrollForElements,
+  combine,
+  extractClosestEdge,
+  monitorForElements,
+} from '../../pdnd.cjs';
 import { assert } from '../../utils/index.js';
 import { useFlashedRowContext } from '../flash_row/flashed_row_context.js';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowJs": false,
     "isolatedModules": true,
-    "verbatimModuleSyntax": true,
+//    "verbatimModuleSyntax": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "allowJs": false,
     "isolatedModules": true,
-//    "verbatimModuleSyntax": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true


### PR DESCRIPTION
Given how @atlaskit/pragmatic-drag-and-drop publishes ESM in a non-native way, we have to trick TS into using the CJS build so that our build is compatible with native ESM.

Closes: https://github.com/zakodium-oss/react-science/issues/899
