### PR TITLE
feat(Accordion): improve renderToolbar API

### DIFF
--- a/src/components/accordion/accordion_context.ts
+++ b/src/components/accordion/accordion_context.ts
@@ -1,12 +1,14 @@
 import { createContext, useContext, useEffect, useMemo } from 'react';
 
 import type {
+  AccordionItemContextValue,
   AccordionItemSetIsOpen,
-  AccordionState,
 } from './accordion_context_utils.js';
 
-export type ContextType = [
-  AccordionContext,
+export type AccordionContextValue = [
+  {
+    unmountChildren: boolean;
+  },
   {
     closeAllExcept: (except: string) => void;
     toggle: (id: string) => void;
@@ -15,15 +17,14 @@ export type ContextType = [
     change: (id: string, isOpen: boolean) => void;
   },
 ];
+export const accordionContext = createContext<AccordionContextValue | null>(
+  null,
+);
 
-type AccordionContext = AccordionState;
-
-export const accordionContext = createContext<ContextType | null>(null);
-
-export function useAccordionContext(
+export function useAccordionItemContext(
   id: string,
   setIsOpen: AccordionItemSetIsOpen,
-) {
+): AccordionItemContextValue {
   const context = useContext(accordionContext);
 
   if (!context) {
@@ -40,9 +41,11 @@ export function useAccordionContext(
   return useMemo(
     () => ({
       unmountChildren: state.unmountChildren,
-      utils: {
+      controls: {
         closeOthers: () => utils.closeAllExcept(id),
         toggle: () => utils.toggle(id),
+        open: () => utils.change(id, true),
+        close: () => utils.change(id, false),
       },
     }),
     [id, utils, state.unmountChildren],

--- a/src/components/accordion/accordion_context_provider.tsx
+++ b/src/components/accordion/accordion_context_provider.tsx
@@ -3,7 +3,7 @@ import { useMemo, useRef } from 'react';
 
 import { assert } from '../utils/index.js';
 
-import type { ContextType } from './accordion_context.js';
+import type { AccordionContextValue } from './accordion_context.js';
 import { accordionContext } from './accordion_context.js';
 import type { AccordionItemSetIsOpen } from './accordion_context_utils.js';
 import { getAccordionRegister } from './accordion_context_utils.js';
@@ -17,7 +17,7 @@ export function AccordionProvider(props: AccordionProviderProps) {
   const { unmountChildren = false, children } = props;
   const registerRef = useRef(getAccordionRegister());
 
-  const utils = useMemo<ContextType[1]>(() => {
+  const utils = useMemo<AccordionContextValue[1]>(() => {
     return {
       change: (id: string, isOpen: boolean) => {
         assert(registerRef.current);
@@ -62,7 +62,7 @@ export function AccordionProvider(props: AccordionProviderProps) {
     };
   }, [registerRef]);
 
-  const contextValue = useMemo<ContextType>(() => {
+  const contextValue = useMemo<AccordionContextValue>(() => {
     return [
       {
         unmountChildren,

--- a/src/components/accordion/accordion_context_utils.ts
+++ b/src/components/accordion/accordion_context_utils.ts
@@ -1,12 +1,15 @@
 import type { Dispatch, SetStateAction } from 'react';
 
-export interface AccordionItemState {
-  title: string;
-  onChange: AccordionItemSetIsOpen;
+export interface AccordionItemControls {
+  closeOthers: () => void;
+  toggle: () => void;
+  open: () => void;
+  close: () => void;
 }
 
-export interface AccordionState {
+export interface AccordionItemContextValue {
   unmountChildren: boolean;
+  controls: AccordionItemControls;
 }
 
 export type AccordionItemSetIsOpen = Dispatch<

--- a/src/components/accordion/index.ts
+++ b/src/components/accordion/index.ts
@@ -1,3 +1,6 @@
 export * from './accordion.js';
 export * from './accordion_context_provider.js';
 export * from './accordion_hooks.js';
+
+// Exported because part of AccordionRenderToolbarProps, which is also exported.
+export type { AccordionItemControls } from './accordion_context_utils.js';

--- a/stories/components/accordion.stories.tsx
+++ b/stories/components/accordion.stories.tsx
@@ -421,19 +421,22 @@ export function WithToolbar() {
   );
 }
 
+type AccordionStoryItemId = 'first' | 'second' | 'third';
+
 export function ControlledState() {
+  const Item = AccordionStoryItem<AccordionStoryItemId>;
   return (
-    <AccordionStoryProvider>
+    <AccordionStoryProvider<AccordionStoryItemId> initialOpenItems={['first']}>
       <Accordion>
-        <AccordionStoryItem id="first" title="First">
+        <Item id="first" title="First">
           First content
-        </AccordionStoryItem>
-        <AccordionStoryItem id="second" title="Second">
+        </Item>
+        <Item id="second" title="Second">
           Second content
-        </AccordionStoryItem>
-        <AccordionStoryItem id="third" title="Third">
+        </Item>
+        <Item id="third" title="Third">
           Third content
-        </AccordionStoryItem>
+        </Item>
       </Accordion>
     </AccordionStoryProvider>
   );

--- a/stories/components/accordion.stories.tsx
+++ b/stories/components/accordion.stories.tsx
@@ -1,10 +1,11 @@
-import { Button } from '@blueprintjs/core';
+import { Button, Icon } from '@blueprintjs/core';
 import { action } from '@storybook/addon-actions';
 import type { Meta } from '@storybook/react';
 import { useState } from 'react';
 
 import type {
   AccordionItemProps,
+  AccordionRenderToolbarProps,
   ToolbarItemProps,
 } from '../../src/components/index.js';
 import {
@@ -252,7 +253,7 @@ export function WithDynamicItems() {
 type WithToggleTitle = 'spectra' | 'integral';
 
 export function WithToggle() {
-  const utils = useAccordionControls<WithToggleTitle>();
+  const controls = useAccordionControls<WithToggleTitle>();
   const TypedAccordionItem = Accordion.Item<WithToggleTitle>;
   return (
     <>
@@ -284,22 +285,22 @@ export function WithToggle() {
                 gap: 5,
               }}
             >
-              <Button onClick={() => utils.open('spectra')}>
+              <Button onClick={() => controls.open('spectra')}>
                 Open Spectra
               </Button>
-              <Button onClick={() => utils.close('spectra')}>
+              <Button onClick={() => controls.close('spectra')}>
                 Close Spectra
               </Button>
-              <Button onClick={() => utils.toggle('spectra')}>
+              <Button onClick={() => controls.toggle('spectra')}>
                 Toggle Spectra
               </Button>
-              <Button onClick={() => utils.open('integral')}>
+              <Button onClick={() => controls.open('integral')}>
                 Open Integral
               </Button>
-              <Button onClick={() => utils.close('integral')}>
+              <Button onClick={() => controls.close('integral')}>
                 Close Integral
               </Button>
-              <Button onClick={() => utils.toggle('integral')}>
+              <Button onClick={() => controls.toggle('integral')}>
                 Toggle Integral
               </Button>
             </div>
@@ -368,19 +369,51 @@ export function UnmountSomeChildren() {
 }
 
 export function WithToolbar() {
-  function renderToolbar(isOpen: boolean) {
-    return <Button icon={isOpen ? 'minus' : 'plus'} variant="minimal" />;
+  const [bellCount, setBellCount] = useState(0);
+  function renderToolbarToggle({
+    isOpen,
+    controls,
+  }: AccordionRenderToolbarProps) {
+    return (
+      <Button
+        icon={isOpen ? 'minus' : 'plus'}
+        variant="minimal"
+        onClick={() => {
+          controls.toggle();
+        }}
+      />
+    );
   }
   return (
     <Accordion>
-      <Accordion.Item id="first" title="First" renderToolbar={renderToolbar}>
+      <Accordion.Item
+        id="first"
+        title="First"
+        renderToolbar={(data) => (
+          <>
+            <Button
+              icon="notifications-add"
+              variant="minimal"
+              onClick={() => {
+                data.controls.open();
+                setBellCount((prev) => prev + 1);
+              }}
+            />
+            {renderToolbarToggle(data)}
+          </>
+        )}
+      >
         First content
+        <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+          <Icon icon="notifications" />
+          {bellCount}
+        </div>
       </Accordion.Item>
       <Accordion.Item
         id="second"
         title="Second"
         defaultOpen
-        renderToolbar={renderToolbar}
+        renderToolbar={renderToolbarToggle}
       >
         Second content
       </Accordion.Item>

--- a/stories/components/activity_bar.stories.tsx
+++ b/stories/components/activity_bar.stories.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@blueprintjs/core';
 import type { Meta } from '@storybook/react';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
@@ -8,11 +9,17 @@ import type {
   ToolbarProps,
 } from '../../src/components/index.js';
 import {
+  Accordion,
   ActivityBar,
   ActivityBarItem,
   ActivityPanel,
   SplitPane,
 } from '../../src/components/index.js';
+
+import {
+  AccordionStoryItem,
+  AccordionStoryProvider,
+} from './accordion_story_helpers.js';
 
 export default {
   title: 'Components / Activity bar and panel',
@@ -134,6 +141,94 @@ export function ActivityToolbarLayout() {
                   </ActivityPanel.Item>
                 ))}
             </ActivityPanel>
+          </SplitPane>
+        ) : (
+          <PlaceHolder />
+        )}
+      </div>
+      <div
+        style={{
+          height: '100%',
+          width: 'fit-content',
+          display: 'flex',
+          flexDirection: 'row-reverse',
+          flexShrink: 1,
+        }}
+      >
+        <ActivityBar>
+          {itemsBlueprintIcons.map((item) => (
+            <ActivityBarItem
+              key={item.id}
+              id={item.id}
+              icon={item.icon}
+              active={selected.includes(item.id)}
+              onClick={() => {
+                setSelected((prev) =>
+                  prev.includes(item.id)
+                    ? prev.filter((id) => id !== item.id)
+                    : [...prev, item.id],
+                );
+              }}
+            />
+          ))}
+        </ActivityBar>
+      </div>
+    </div>
+  );
+}
+
+export function ActivityToolbarLayoutWithAccordions() {
+  const [selected, setSelected] = useState<string[]>([
+    'phone',
+    'add-column-left',
+  ]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+      }}
+    >
+      <div
+        style={{
+          flexGrow: 1,
+        }}
+      >
+        {selected.length > 0 ? (
+          <SplitPane defaultSize="30%" controlledSide="end">
+            <PlaceHolder />
+            <AccordionStoryProvider
+              initialOpenItems={itemsBlueprintIcons.map((item) => item.id)}
+            >
+              <Accordion>
+                {itemsBlueprintIcons
+                  .filter((item) => selected.includes(item.id))
+                  .map(({ id }) => (
+                    <AccordionStoryItem
+                      key={id}
+                      id={id}
+                      title={id}
+                      renderToolbar={({ id }) => (
+                        <Button
+                          onClick={() => {
+                            setSelected((prev) =>
+                              prev.filter((listId) => listId !== id),
+                            );
+                          }}
+                          icon="cross"
+                          variant="minimal"
+                        />
+                      )}
+                    >
+                      <div>
+                        This is the content of <strong>{id}</strong>.
+                      </div>
+                    </AccordionStoryItem>
+                  ))}
+              </Accordion>
+            </AccordionStoryProvider>
           </SplitPane>
         ) : (
           <PlaceHolder />


### PR DESCRIPTION
Ref: https://github.com/zakodium/peak-by-peak/issues/360

BREAKING-CHANGE: The render callback parameter has changed to contain multiple properties instead of just the `isOpen` state. It can now be used to control the state of the item in which it is rendered. Click events in the toolbar no longer propagate to the header in order to prevent it from toggling if it is not wanted.
