### PR TITLE
feat: improve fullscreen error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tanstack/react-virtual": "^3.13.2",
         "d3-scale-chromatic": "^3.1.0",
         "react-dropzone": "^14.3.8",
+        "react-full-screen": "^1.1.1",
         "react-icons": "^5.5.0",
         "react-inspector": "^6.0.2",
         "tinycolor2": "^1.6.0",
@@ -6282,6 +6283,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fscreen": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.2.0.tgz",
+      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -9290,6 +9297,21 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-full-screen": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-full-screen/-/react-full-screen-1.1.1.tgz",
+      "integrity": "sha512-xoEgkoTiN0dw9cjYYGViiMCBYbkS97BYb4bHPhQVWXj1UnOs8PZ1rPzpX+2HMhuvQV1jA5AF9GaRbO3fA5aZtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fscreen": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/react-icons": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@tanstack/react-virtual": "^3.13.2",
     "d3-scale-chromatic": "^3.1.0",
     "react-dropzone": "^14.3.8",
+    "react-full-screen": "^1.1.1",
     "react-icons": "^5.5.0",
     "react-inspector": "^6.0.2",
     "tinycolor2": "^1.6.0",

--- a/src/components/fullscreen/fullscreen_context.provider.tsx
+++ b/src/components/fullscreen/fullscreen_context.provider.tsx
@@ -1,86 +1,49 @@
-/* eslint-disable no-alert */
-import type { ReactNode, RefObject } from 'react';
-import { useEffect, useMemo, useReducer, useRef } from 'react';
+import type { MutableRefObject, ReactNode } from 'react';
+import { useMemo } from 'react';
+import { useFullScreenHandle } from 'react-full-screen';
 
-import { fullscreenContext, useFullscreen } from './fullscreen_context.js';
+import { fullscreenContext } from './fullscreen_context.js';
 
-type ElementType = HTMLDivElement & {
-  webkitRequestFullscreen(): Promise<void>;
-};
-
-type DocumentType = Document & {
-  webkitExitFullscreen(): Promise<void>;
-  webkitFullscreenElement: Element | null;
-};
-interface FullscreenProps {
+export interface FullscreenProviderProps {
   /**
    * Callback providing the ref which should be passed to the element that can be displayed fullscreen.
    * @param ref
    */
-  children: (ref: RefObject<HTMLDivElement>) => ReactNode;
+  children: (ref: MutableRefObject<HTMLDivElement | null>) => ReactNode;
+  /**
+   * Callback which will be called in case toggling results in an error.
+   * @param error - The error that happened. Value is not necessarily an instance of `Error` and may even be `undefined`.
+   * @param step - Indicates if the error happened when entering or exiting the full screen.
+   */
+  onToggleError?: (error: unknown, step: 'enter' | 'exit') => void;
 }
 
-export function FullScreenProvider(props: FullscreenProps) {
-  const [isFullScreen, toggle] = useReducer((value: boolean) => !value, false);
+export function FullScreenProvider(props: FullscreenProviderProps) {
+  const { children, onToggleError } = props;
 
-  const value = useMemo(
-    () => ({ isFullScreen, toggle }),
-    [isFullScreen, toggle],
-  );
+  const handle = useFullScreenHandle();
+
+  const value = useMemo(() => {
+    function toggle() {
+      const handleToggle = handle.active ? handle.exit : handle.enter;
+      function handleError(error: unknown) {
+        onToggleError?.(error, handle.active ? 'exit' : 'enter');
+      }
+      try {
+        handleToggle().catch(handleError);
+      } catch (error) {
+        handleError(error);
+      }
+    }
+    return {
+      isFullScreen: handle.active,
+      toggle,
+    };
+  }, [handle, onToggleError]);
+
   return (
     <fullscreenContext.Provider value={value}>
-      <FullscreenInner {...props} />
+      {children(handle.node)}
     </fullscreenContext.Provider>
   );
-}
-function FullscreenInner(props: FullscreenProps) {
-  const { children } = props;
-  const { isFullScreen, toggle } = useFullscreen();
-  const ref = useRef<ElementType>(null);
-  useEffect(() => {
-    function onFullscreenChange() {
-      const document = window.document as DocumentType;
-      const value = Boolean(
-        document.fullscreenElement || document.webkitFullscreenElement,
-      );
-      if (!value && isFullScreen) toggle();
-    }
-    const div = ref.current;
-    if (!div) {
-      return;
-    }
-    div.addEventListener('fullscreenchange', onFullscreenChange);
-    div.addEventListener('webkitfullscreenchange', onFullscreenChange);
-
-    return () => {
-      div.removeEventListener('fullscreenchange', onFullscreenChange);
-      div.removeEventListener('webkitfullscreenchange', onFullscreenChange);
-    };
-  }, [isFullScreen, toggle]);
-  useEffect(() => {
-    if (isFullScreen && ref.current) {
-      if (ref.current.requestFullscreen) {
-        ref.current.requestFullscreen().catch(() => {
-          window.alert('Fullscreen is not supported');
-        });
-      } else if (ref.current.webkitRequestFullscreen) {
-        ref.current.webkitRequestFullscreen()?.catch(() => {
-          window.alert('Fullscreen is not supported');
-        });
-      }
-    }
-    const document = window.document as DocumentType;
-    if (!isFullScreen && document.fullscreenElement) {
-      if (document.exitFullscreen) {
-        document.exitFullscreen().catch(() => {
-          window.alert("Can't exit fullscreen");
-        });
-      } else if (document.webkitExitFullscreen) {
-        document.webkitExitFullscreen().catch(() => {
-          window.alert("Can't exit fullscreen");
-        });
-      }
-    }
-  }, [isFullScreen]);
-  return children(ref);
 }

--- a/src/components/root-layout/root_layout.tsx
+++ b/src/components/root-layout/root_layout.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, MutableRefObject, ReactNode } from 'react';
 import { useCallback, useState } from 'react';
 
 import { AccordionProvider } from '../accordion/index.js';
+import type { FullscreenProviderProps } from '../fullscreen/index.js';
 import { FullScreenProvider } from '../fullscreen/index.js';
 
 import { CustomDivPreflight } from './css-reset/customPreflight.js';
@@ -11,8 +12,9 @@ import { RootLayoutProvider } from './root_layout_context.provider.js';
 FocusStyleManager.onlyShowFocusOnTabs();
 
 interface RootLayoutProps {
-  style?: CSSProperties;
   children: ReactNode;
+  style?: CSSProperties;
+  onFullscreenToggleError?: FullscreenProviderProps['onToggleError'];
 }
 
 const style: CSSProperties = {
@@ -35,13 +37,14 @@ export function RootLayout(props: RootLayoutProps) {
   }, []);
 
   return (
-    <FullScreenProvider>
-      {(ref) => (
+    <FullScreenProvider onToggleError={props.onFullscreenToggleError}>
+      {(fullscreenRef) => (
         <CustomDivPreflight
           id="root-layout"
           ref={(node) => {
             if (node) {
-              const mutableRef = ref as MutableRefObject<HTMLDivElement>;
+              const mutableRef =
+                fullscreenRef as MutableRefObject<HTMLDivElement>;
               mutableRef.current = node;
               refCallback(node);
             }

--- a/stories/components/fullscreen.stories.tsx
+++ b/stories/components/fullscreen.stories.tsx
@@ -13,7 +13,12 @@ export default {
 
 export function Basic() {
   return (
-    <FullScreenProvider>
+    <FullScreenProvider
+      onToggleError={(error, step) =>
+        // eslint-disable-next-line no-alert
+        window.alert(`Fullscreen error during "${step}"`)
+      }
+    >
       {(page1) => (
         <FullPageRoot ref={page1} color="green">
           <FullPageContent i="1">

--- a/stories/components/fullscreen.stories.tsx
+++ b/stories/components/fullscreen.stories.tsx
@@ -14,10 +14,14 @@ export default {
 export function Basic() {
   return (
     <FullScreenProvider
-      onToggleError={(error, step) =>
+      onToggleError={(error, step) => {
+        // eslint-disable-next-line no-console
+        console.error(error, step);
         // eslint-disable-next-line no-alert
-        window.alert(`Fullscreen error during "${step}"`)
-      }
+        window.alert(
+          `Fullscreen error during "${step}". See the browser console for details.`,
+        );
+      }}
     >
       {(page1) => (
         <FullPageRoot ref={page1} color="green">


### PR DESCRIPTION
> Use a library to manage fullscreen APIs.
> Also add a `onToggleError` prop to the `FullScreenProvider` and `RootLayout` components.
>
> There is a behavior change with "stacked" fullscreen elements (like in the storybook). Now when you enter fullscreen a second time, it will first exit the previous fullscreen. I think it's fine. We don't (and probably shouldn't) use stacked fullscreens in real apps.

I'm not sure about the `onToggleError` prop. Another option is to make the `toggle()` function async, but then the user has to handle it otherwise it will be an unhandled rejection (which for example will trigger error monitors like Sentry).