### PR TITLE
fix: correct incompatibilities when blueprint stylesheet is in a css layer

### DIFF
--- a/src/components/activity_bar/activity_bar.tsx
+++ b/src/components/activity_bar/activity_bar.tsx
@@ -59,15 +59,6 @@ const ActivityButton = styled(Button)`
   }
 `;
 
-const ActivityButtonIconContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 0;
-  height: 0;
-  margin-right: 0;
-`;
-
 export function ActivityBarItem(props: ActivityBarItemProps) {
   const {
     active = false,
@@ -91,11 +82,6 @@ export function ActivityBarItem(props: ActivityBarItemProps) {
     <ActivityButton
       type="button"
       active={active}
-      icon={
-        <ActivityButtonIconContainer>
-          <Icon icon={resizedIcon} size={20} />
-        </ActivityButtonIconContainer>
-      }
       onClick={onClick}
       tooltipProps={
         !tooltip
@@ -109,7 +95,13 @@ export function ActivityBarItem(props: ActivityBarItemProps) {
             }
       }
       {...otherProps}
-    />
+    >
+      {typeof resizedIcon === 'string' ? (
+        <Icon icon={resizedIcon} size={20} />
+      ) : (
+        resizedIcon
+      )}
+    </ActivityButton>
   );
 }
 

--- a/src/components/activity_bar/activity_bar.tsx
+++ b/src/components/activity_bar/activity_bar.tsx
@@ -1,11 +1,11 @@
 import type { TooltipProps } from '@blueprintjs/core';
-import { ButtonGroup, Classes, Colors, Icon } from '@blueprintjs/core';
+import { ButtonGroup, Classes, Colors } from '@blueprintjs/core';
 import styled from '@emotion/styled';
 import type { MouseEvent, ReactNode } from 'react';
-import { cloneElement } from 'react';
 
 import type { ButtonProps } from '../button/index.js';
 import { Button } from '../button/index.js';
+import { normalizeIcon } from '../icon.js';
 
 export interface ActivityBarProps {
   children: ReactNode;
@@ -45,12 +45,6 @@ const ActivityButton = styled(Button)`
     color: ${Colors.DARK_GRAY3};
   }
 
-  .${Classes.ICON} {
-    width: 20px;
-    height: 20px;
-    font-size: 14px;
-  }
-
   .${Classes.TAG} {
     font-size: 12px;
     line-height: 14px;
@@ -69,14 +63,7 @@ export function ActivityBarItem(props: ActivityBarItemProps) {
     ...otherProps
   } = props;
 
-  const resizedIcon =
-    !icon || typeof icon === 'string'
-      ? icon
-      : cloneElement(icon, {
-          className: icon.props.className
-            ? `${icon.props.className} ${Classes.ICON}`
-            : Classes.ICON,
-        });
+  const resizedIcon = normalizeIcon(icon, 20);
 
   return (
     <ActivityButton
@@ -96,11 +83,7 @@ export function ActivityBarItem(props: ActivityBarItemProps) {
       }
       {...otherProps}
     >
-      {typeof resizedIcon === 'string' ? (
-        <Icon icon={resizedIcon} size={20} />
-      ) : (
-        resizedIcon
-      )}
+      {resizedIcon}
     </ActivityButton>
   );
 }

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -7,7 +7,6 @@ import type {
 import {
   AnchorButton,
   Button as BlueprintButton,
-  Classes,
   Icon,
   Tag,
   Tooltip,
@@ -15,7 +14,6 @@ import {
 import type { CSSObject } from '@emotion/styled';
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
-import { Fragment } from 'react';
 
 type BlueprintProps = {
   [key in keyof BlueprintButtonProps &
@@ -46,22 +44,17 @@ const ButtonTag = styled(Tag)`
 // Setting the line-height makes sure regular sized buttons have a
 // height consistent with the input fields and across variants.
 // Using the same line height as in the blueprint docs.
-function getStyledCss(
-  buttonProps: BlueprintAnchorButtonProps | BlueprintButtonProps,
-): CSSObject {
-  return {
-    lineHeight: 1.15,
-    position: 'relative',
-    [`.${Classes.ICON}`]: !buttonProps.children && { marginRight: 0 },
-  };
-}
+const buttonStyles: CSSObject = {
+  lineHeight: 1.15,
+  position: 'relative',
+};
 
 const TooltipAnchorButton = styled(AnchorButton)<{
   children: ReactNode;
-}>(getStyledCss);
+}>(buttonStyles);
 
 const TooltipButton = styled(BlueprintButton)<{ children: ReactNode }>(
-  getStyledCss,
+  buttonStyles,
 );
 
 export function Button(props: ButtonProps) {
@@ -88,14 +81,31 @@ export function Button(props: ButtonProps) {
           {...targetProps}
           {...buttonProps}
           icon={
-            <Fragment>
-              <Icon icon={buttonProps.icon} />
-              {tag && (
+            /*
+             icon and children will be children of the same node.
+             Blueprintjs' stylesheet treats the presence of multiple child elements
+             as there being icon and text, styling the icon with a right margin
+             so that the text is not right next to it.
+             In blueprint alone, this only happens when the button has children.
+             Here, we need to handle the case when the button has a tag, which
+             adds a sibling but should not affect the margin on its own.
+            */
+            tag ? (
+              <>
+                {children ? (
+                  <Icon icon={buttonProps.icon} />
+                ) : (
+                  <div style={{ display: 'contents' }}>
+                    <Icon icon={buttonProps.icon} />
+                  </div>
+                )}
                 <ButtonTag round intent="success" {...tagProps}>
                   {tag}
                 </ButtonTag>
-              )}
-            </Fragment>
+              </>
+            ) : (
+              buttonProps.icon
+            )
           }
         >
           {children}

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,0 +1,25 @@
+import type { ButtonProps } from '@blueprintjs/core';
+import { Classes, Icon } from '@blueprintjs/core';
+import { cloneElement } from 'react';
+
+/**
+ * Return a normalized icon.
+ * Accepts a blueprint icon id or a custom element.
+ */
+export function normalizeIcon(icon: ButtonProps['icon'], size: number) {
+  return !icon || typeof icon === 'string' ? (
+    <Icon icon={icon} size={size} />
+  ) : (
+    cloneElement(icon, {
+      style: {
+        width: size,
+        height: size,
+        fontSize: size - 4,
+        textAlign: 'center',
+      },
+      className: icon.props.className
+        ? `${icon.props.className} ${Classes.ICON}`
+        : Classes.ICON,
+    })
+  );
+}

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -14,6 +14,8 @@ export function normalizeIcon(icon: ButtonProps['icon'], size: number) {
       style: {
         width: size,
         height: size,
+        // In a toolbar, icon size is 16 and font size 12
+        // In an activity toolbar, icon size is 20 and font size 16
         fontSize: size - 4,
         textAlign: 'center',
       },

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -7,10 +7,11 @@ import type {
 import { ButtonGroup, Classes, Colors, Icon, Popover } from '@blueprintjs/core';
 import styled from '@emotion/styled';
 import type { MouseEvent, ReactNode } from 'react';
-import { cloneElement, useLayoutEffect, useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 
 import type { ButtonProps } from '../button/index.js';
 import { Button } from '../button/index.js';
+import { normalizeIcon } from '../icon.js';
 
 import type { ToolbarContext } from './toolbarContext.js';
 import { toolbarContext, useToolbarContext } from './toolbarContext.js';
@@ -163,18 +164,10 @@ function ToolbarItemInternal(props: ToolbarItemInternalProps) {
   const intent = itemIntent ?? toolbarIntent;
   const disabled = itemDisabled ?? toolbarDisabled;
 
-  const resizedIcon =
-    !icon || typeof icon === 'string'
-      ? icon
-      : cloneElement(icon, {
-          className: icon.props.className
-            ? `${icon.props.className} ${Classes.ICON}`
-            : Classes.ICON,
-        });
+  const normalizedIcon = normalizeIcon(icon, 16);
 
   return (
     <ToolbarButton
-      alignText={isPopover ? 'start' : undefined}
       disabled={disabled}
       intent={intent}
       type="button"
@@ -185,32 +178,28 @@ function ToolbarItemInternal(props: ToolbarItemInternalProps) {
         width: 'fit-content',
       }}
       icon={
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            width: 0,
-            height: 0,
-            marginRight: 0,
-          }}
-        >
-          <Icon icon={resizedIcon} size={16} />
-          {isPopover && (
-            <Icon
-              icon="caret-right"
-              size={9}
-              style={{
-                transform: 'rotate(45deg)',
-                position: 'absolute',
-                bottom: 0,
-                right: 0,
-                width: 9,
-                height: 9,
-              }}
-            />
+        <>
+          {isPopover ? (
+            <>
+              {/*For the icon to be properly styled, it should not have any siblings*/}
+              <div style={{ display: 'contents' }}>{normalizedIcon}</div>
+              <Icon
+                icon="caret-right"
+                size={9}
+                style={{
+                  transform: 'rotate(45deg)',
+                  position: 'absolute',
+                  bottom: 0,
+                  right: 0,
+                  width: 9,
+                  height: 9,
+                }}
+              />
+            </>
+          ) : (
+            normalizedIcon
           )}
-        </div>
+        </>
       }
       onClick={onClick}
       tooltipProps={

--- a/stories/components/activity_bar.stories.tsx
+++ b/stories/components/activity_bar.stories.tsx
@@ -62,6 +62,10 @@ const itemsBlueprintIcons: ActivityBarStoryItem[] = [
     tooltip: 'Box icons credit card icon',
     disabled: true,
   },
+  {
+    id: 'custom-text',
+    icon: <span>IC</span>,
+  },
 ];
 
 export function ActivityBarControl(

--- a/stories/components/activity_bar.stories.tsx
+++ b/stories/components/activity_bar.stories.tsx
@@ -2,6 +2,8 @@ import { Button } from '@blueprintjs/core';
 import type { Meta } from '@storybook/react';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
+import { BiCreditCard } from 'react-icons/bi';
+import { HiCreditCard } from 'react-icons/hi2';
 
 import type {
   ActivityBarItemProps,
@@ -46,11 +48,20 @@ const itemsBlueprintIcons: ActivityBarStoryItem[] = [
     icon: 'redo',
     tooltip: 'Redo',
   },
-  { id: 'undo', icon: 'undo', tooltip: 'Undo' },
-  { id: 'paperclip', icon: 'paperclip', tooltip: 'Attachment' },
   { id: 'help', icon: 'help', tooltip: 'Help' },
   { id: 'lab-test', icon: 'lab-test', tooltip: 'Lab', disabled: true },
   { id: 'trash', icon: 'trash', tooltip: 'Trash' },
+  {
+    id: 'credit-card-hi2',
+    icon: <HiCreditCard />,
+    tooltip: 'Heroicons credit card icon',
+  },
+  {
+    id: 'credit-card-bi',
+    icon: <BiCreditCard />,
+    tooltip: 'Box icons credit card icon',
+    disabled: true,
+  },
 ];
 
 export function ActivityBarControl(


### PR DESCRIPTION
- **fix: correct toolbar button when blueprint css is in a layer**
- **refactor: simplify markup for activity item**
- **fix: make sure the toolbar buttons are properly centered when blueprint styles are in a layer.**
