### PR TITLE
927 splitpane do not render side when size is 0

### DIFF
--- a/src/components/split_pane/split_pane.tsx
+++ b/src/components/split_pane/split_pane.tsx
@@ -85,6 +85,12 @@ export interface SplitPaneProps {
   onSizeChange?: (size: SplitPaneSize) => void;
 
   /**
+   * When set to true, only visible children will be rendered. If a side is closed or has a size of 0, it will not be rendered at all.
+   * When not set or set to false, closed sides will be hidden, and open sides with a size of 0 will still render their children.
+   */
+  unmountChildren?: boolean;
+
+  /**
    * The two React elements to show on both sides of the pane.
    * If one of the elements is `null`, the splitter will disappear and the
    * other element will take the full space.
@@ -105,6 +111,7 @@ export function SplitPane(props: SplitPaneProps) {
     closeThreshold = null,
     onResize,
     onOpenChange,
+    unmountChildren = false,
     children,
   } = props;
 
@@ -113,6 +120,7 @@ export function SplitPane(props: SplitPaneProps) {
     defaultProp: defaultOpen,
     onChange: onOpenChange,
   });
+
   const [size, setSize] = useControllableState<SplitPaneSize>({
     prop: sizeProp,
     defaultProp: defaultSize,
@@ -169,9 +177,26 @@ export function SplitPane(props: SplitPaneProps) {
     );
   }
 
+  function shouldMountSide(side: SplitPaneSide) {
+    if (!unmountChildren) {
+      return true;
+    }
+    return isSideVisible(
+      isOpen ?? defaultOpen,
+      controlledSide === side,
+      splitSize,
+      sizeType,
+      rootSize
+        ? direction === 'horizontal'
+          ? rootSize.width
+          : rootSize.height
+        : 0,
+    );
+  }
+
   return (
     <SplitPaneContainer direction={direction} ref={rootRef}>
-      {children[0] !== null && (
+      {children[0] !== null && shouldMountSide('start') && (
         <SplitSide style={getSplitSideStyle('start')}>{children[0]}</SplitSide>
       )}
       {children[0] !== null && children[1] !== null && (
@@ -185,7 +210,7 @@ export function SplitPane(props: SplitPaneProps) {
         />
       )}
 
-      {children[1] !== null && (
+      {children[1] !== null && shouldMountSide('end') && (
         <SplitSide style={getSplitSideStyle('end')}>{children[1]}</SplitSide>
       )}
     </SplitPaneContainer>
@@ -240,6 +265,22 @@ const flexBase = 100;
 function percentToFlex(percent: number): number {
   percent /= 100;
   return (flexBase - percent * flexBase) / percent;
+}
+
+function isSideVisible(
+  isOpen: boolean,
+  isControlledSide: boolean,
+  size: number,
+  type: SplitPaneType,
+  parentSize: number,
+) {
+  if (!isOpen) {
+    return !isControlledSide;
+  } else if (type === '%') {
+    return isControlledSide ? size !== 0 : size !== 100;
+  } else {
+    return isControlledSide ? size !== 0 : size !== parentSize;
+  }
 }
 
 function getItemStyle(

--- a/src/components/split_pane/split_pane.tsx
+++ b/src/components/split_pane/split_pane.tsx
@@ -86,7 +86,7 @@ export interface SplitPaneProps {
 
   /**
    * When set to true, only visible children will be rendered. If a side is closed or has a size of 0, it will not be rendered at all.
-   * When not set or set to false, closed sides will be hidden, and open sides with a size of 0 will still render their children.
+   * When not set or set to false, closed or otherwise 0-sized sides will still be rendered.
    */
   unmountChildren?: boolean;
 

--- a/stories/components/split_pane.stories.tsx
+++ b/stories/components/split_pane.stories.tsx
@@ -63,6 +63,17 @@ Horizontal.args = {
   defaultSize: '30%',
 };
 
+export const SizeInPixels = {
+  render: (props: SplitPaneProps) => (
+    <div style={{ height: 400, width: 600 }}>
+      <SplitPane {...props} />
+    </div>
+  ),
+  args: {
+    defaultSize: '200px',
+  },
+};
+
 export function EndSideIsControlled(props: SplitPaneProps) {
   return (
     <div style={{ height: 400, width: 600 }}>


### PR DESCRIPTION
- **feat(SplitPane): add prop to unmount any invisible split pane side**
- **docs: add an example which uses a size in pixels, not percent**
