### PR TITLE
feat: provide `AppForm` component

### DIFF
--- a/src/components/form/components/input_groups/form.tsx
+++ b/src/components/form/components/input_groups/form.tsx
@@ -9,6 +9,13 @@ export interface FormProps extends FormHTMLAttributes<HTMLFormElement> {
   layout?: Layout;
 }
 
+/**
+ * @param props
+ * @deprecated Use `AppForm` instead.
+ * This component will be merged into `AppForm` and removed in a next major release.
+ * During migration, consider removing the `onSubmit` props.
+ * If you did not bound `noValidate` props, you will have to bound `domValidate` to `AppForm`.
+ */
 export function Form(props: FormProps) {
   const { children, layout = 'stacked', ...otherProps } = props;
 

--- a/src/components/form/components/layout/form.tsx
+++ b/src/components/form/components/layout/form.tsx
@@ -1,0 +1,60 @@
+import type { SyntheticEvent } from 'react';
+
+import { withForm } from '../../context/use_ts_form.js';
+import type { FormProps as DomFormProps } from '../input_groups/form.js';
+import { Form as DomForm } from '../input_groups/form.js';
+
+export interface AppFormProps extends Omit<DomFormProps, 'noValidate'> {
+  domValidate?: boolean;
+  /**
+   * should return meta to pass to `form.handleSubmit`
+   */
+  // Generic meta-result is not possible with higher order component pattern
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSubmitMeta?: (event: SyntheticEvent<HTMLFormElement, SubmitEvent>) => any;
+}
+
+const props: AppFormProps = { children: null };
+
+// AppForm is a generic component for all forms
+// it will not touch to values inside the form,
+// and unknown is not possible.
+// <AppForm form={form}> would throw an error like "unknown is not compatible with <inferred values type>"
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const defaultValues: any = undefined;
+
+/**
+ * Mount `form.AppForm` and `Form` with default onSubmit.
+ * It reduces the boilerplate code.
+ */
+export const AppForm = withForm({
+  defaultValues,
+  props,
+  render: function FormRender(props) {
+    const { form, children, domValidate, onSubmitMeta, ...domProps } = props;
+    const { AppForm } = form;
+
+    return (
+      <AppForm>
+        {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+        <DomForm
+          onSubmit={(event) => {
+            event.preventDefault();
+
+            const meta = onSubmitMeta?.(
+              // onSubmit event is not typed properly.
+              // It uses Event instead of SubmitEvent.
+              event as SyntheticEvent<HTMLFormElement, SubmitEvent>,
+            );
+
+            void form.handleSubmit(meta);
+          }}
+          {...domProps}
+          noValidate={!domValidate}
+        >
+          {children}
+        </DomForm>
+      </AppForm>
+    );
+  },
+});

--- a/src/components/form/components/layout/index.ts
+++ b/src/components/form/components/layout/index.ts
@@ -1,1 +1,2 @@
 export { type Section as _Section } from './Section.js';
+export { AppForm, type AppFormProps } from './form.js';

--- a/stories/components/form/tanstack/app-form.stories.tsx
+++ b/stories/components/form/tanstack/app-form.stories.tsx
@@ -1,0 +1,115 @@
+import styled from '@emotion/styled';
+import type { Meta } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { z } from 'zod';
+
+import type { AppFormProps } from '../../../../src/components/index.ts';
+import { AppForm, useForm } from '../../../../src/components/index.ts';
+
+type Props = Pick<AppFormProps, 'layout'>;
+
+export default {
+  title: 'Forms/Form/Tanstack/AppForm',
+  argTypes: {
+    layout: {
+      control: 'select',
+      options: ['inline', 'stacked'],
+    },
+  },
+  args: {
+    layout: 'inline',
+  },
+} as Meta<Props>;
+
+const schema = z.object({
+  name: z.string().min(1),
+  // coerce number must be annotated, otherwise tanstack form inference will throw error
+  // due to `age: unknown` in defaultValues
+  age: z.coerce.number<string>().min(18),
+});
+
+const defaultValues: z.input<typeof schema> = {
+  name: '',
+  age: '',
+};
+
+export function SimpleAppForm(props: Pick<AppFormProps, 'layout'>) {
+  const form = useForm({
+    defaultValues,
+    validators: { onDynamic: schema, onSubmit: schema },
+    onSubmit: ({ value }) => {
+      const parsedValue = schema.parse(value);
+      action('onSubmit')(parsedValue);
+    },
+    onSubmitInvalid({ value }) {
+      action('onSubmitInvalid')(value);
+    },
+  });
+  const { AppField, SubmitButton, ResetButton } = form;
+
+  return (
+    <AppForm form={form} layout={props.layout}>
+      <AppField name="name">
+        {({ Input }) => <Input label="Name" required />}
+      </AppField>
+      <AppField name="age">
+        {({ NumericInput }) => <NumericInput label="Age" required />}
+      </AppField>
+
+      <Actions>
+        <ResetButton>Reset</ResetButton>
+        <SubmitButton>Submit</SubmitButton>
+      </Actions>
+    </AppForm>
+  );
+}
+
+const onSubmitMetaSchema = z.enum(['apply', 'submit']);
+const onSubmitMeta: z.output<typeof onSubmitMetaSchema> = 'submit';
+
+export function MetaAppForm(props: Pick<AppFormProps, 'layout'>) {
+  const form = useForm({
+    defaultValues,
+    validators: { onDynamic: schema, onSubmit: schema },
+    onSubmitMeta,
+    onSubmit: ({ value, meta }) => {
+      const parsedValue = schema.parse(value);
+      action('onSubmit')({ parsedValue, meta });
+    },
+    onSubmitInvalid({ value, meta }) {
+      action('onSubmitInvalid')({ value, meta });
+    },
+  });
+  const { AppField, SubmitButton, ResetButton } = form;
+
+  return (
+    <AppForm
+      form={form}
+      layout={props.layout}
+      onSubmitMeta={(event) => {
+        const submitter = event.nativeEvent.submitter;
+        const parsed = onSubmitMetaSchema.safeParse(submitter?.dataset.meta);
+        return parsed.success ? parsed.data : 'submit';
+      }}
+    >
+      <AppField name="name">
+        {({ Input }) => <Input label="Name" required />}
+      </AppField>
+      <AppField name="age">
+        {({ NumericInput }) => <NumericInput label="Age" required />}
+      </AppField>
+
+      <Actions>
+        <ResetButton>Reset</ResetButton>
+        <SubmitButton data-meta="apply">Apply</SubmitButton>
+        <SubmitButton data-meta="submit">Submit</SubmitButton>
+      </Actions>
+    </AppForm>
+  );
+}
+
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+`;

--- a/stories/components/form/tanstack/field-groups.stories.tsx
+++ b/stories/components/form/tanstack/field-groups.stories.tsx
@@ -4,19 +4,19 @@ import type { ReactNode } from 'react';
 import { action } from 'storybook/actions';
 import { z } from 'zod';
 
-import type { FormProps } from '../../../../src/components/form/components/input_groups/form.js';
-import { Form } from '../../../../src/components/form/components/input_groups/form.js';
 import type {
   SVGLineStyleFieldsProps,
   SVGTextStyleFieldsProps,
 } from '../../../../src/components/index.js';
 import {
+  AppForm,
   FieldGroupSVGLineStyleFields,
   FieldGroupSVGTextStyleFields,
   svgLineStyleFieldsSchema,
   svgTextStyleFieldsSchema,
   useForm,
 } from '../../../../src/components/index.js';
+import type { FormProps } from '../../../../src/components/index.ts';
 
 const meta: Meta = {
   title: 'Forms / Form / Tanstack / FieldGroups',
@@ -58,24 +58,15 @@ export const SVGTextStyle: StoryObj<
     });
 
     return (
-      <form.AppForm>
-        <Form
-          layout={layout}
-          style={{ margin: '5px' }}
-          onSubmit={(event) => {
-            event.preventDefault();
-            void form.handleSubmit(event);
-          }}
-        >
-          <FieldGroupSVGTextStyleFields
-            form={form}
-            fields="textStyle"
-            label={label}
-            previewText={previewText}
-          />
-          <form.SubmitButton>Save</form.SubmitButton>
-        </Form>
-      </form.AppForm>
+      <AppForm form={form} layout={layout} style={{ margin: '5px' }}>
+        <FieldGroupSVGTextStyleFields
+          form={form}
+          fields="textStyle"
+          label={label}
+          previewText={previewText}
+        />
+        <form.SubmitButton>Save</form.SubmitButton>
+      </AppForm>
     );
   },
 };
@@ -108,23 +99,14 @@ export const SVGLineStyle: StoryObj<
     });
 
     return (
-      <form.AppForm>
-        <Form
-          layout={layout}
-          style={{ margin: '5px' }}
-          onSubmit={(event) => {
-            event.preventDefault();
-            void form.handleSubmit(event);
-          }}
-        >
-          <FieldGroupSVGLineStyleFields
-            form={form}
-            fields="lineStyle"
-            label={label}
-          />
-          <form.SubmitButton>Save</form.SubmitButton>
-        </Form>
-      </form.AppForm>
+      <AppForm form={form} layout={layout} style={{ margin: '5px' }}>
+        <FieldGroupSVGLineStyleFields
+          form={form}
+          fields="lineStyle"
+          label={label}
+        />
+        <form.SubmitButton>Save</form.SubmitButton>
+      </AppForm>
     );
   },
 };

--- a/stories/components/form/tanstack/field-groups.stories.tsx
+++ b/stories/components/form/tanstack/field-groups.stories.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { revalidateLogic } from '@tanstack/react-form';
 import type { ReactNode } from 'react';
@@ -29,6 +30,10 @@ const meta: Meta = {
 };
 export default meta;
 
+const AppFormStyled = styled(AppForm)`
+  margin: 5px;
+`;
+
 const svgTextStyleFormSchema = z.object({
   textStyle: svgTextStyleFieldsSchema,
 });
@@ -58,7 +63,7 @@ export const SVGTextStyle: StoryObj<
     });
 
     return (
-      <AppForm form={form} layout={layout} style={{ margin: '5px' }}>
+      <AppFormStyled form={form} layout={layout}>
         <FieldGroupSVGTextStyleFields
           form={form}
           fields="textStyle"
@@ -66,7 +71,7 @@ export const SVGTextStyle: StoryObj<
           previewText={previewText}
         />
         <form.SubmitButton>Save</form.SubmitButton>
-      </AppForm>
+      </AppFormStyled>
     );
   },
 };
@@ -99,14 +104,14 @@ export const SVGLineStyle: StoryObj<
     });
 
     return (
-      <AppForm form={form} layout={layout} style={{ margin: '5px' }}>
+      <AppFormStyled form={form} layout={layout}>
         <FieldGroupSVGLineStyleFields
           form={form}
           fields="lineStyle"
           label={label}
         />
         <form.SubmitButton>Save</form.SubmitButton>
-      </AppForm>
+      </AppFormStyled>
     );
   },
 };

--- a/stories/components/form/tanstack/new-general-settings.stories.tsx
+++ b/stories/components/form/tanstack/new-general-settings.stories.tsx
@@ -4,9 +4,9 @@ import { revalidateLogic } from '@tanstack/react-form';
 import { action } from 'storybook/actions';
 import { z } from 'zod';
 
-import { Form } from '../../../../src/components/form/components/input_groups/form.js';
 import type { Layout } from '../../../../src/components/form/components/input_groups/form_context.js';
 import {
+  AppForm,
   FieldGroupSVGTextStyleFields,
   svgTextStyleFieldsSchema,
   useForm,
@@ -25,7 +25,7 @@ export default {
   },
 } as Meta;
 
-const StyledForm = styled(Form)`
+const StyledForm = styled(AppForm)`
   max-width: 605px;
   display: flex;
   flex-direction: column;
@@ -148,14 +148,7 @@ export function GeneralSettings(props: GeneralSettingsProps) {
   });
 
   return (
-    <StyledForm
-      noValidate
-      layout={layout}
-      onSubmit={(event) => {
-        event.preventDefault();
-        void form.handleSubmit();
-      }}
-    >
+    <StyledForm form={form} layout={layout}>
       <form.Section
         title="General"
         description="These settings affect the entire application."
@@ -328,9 +321,7 @@ export function GeneralSettings(props: GeneralSettingsProps) {
         />
       </form.Section>
 
-      <form.AppForm>
-        <form.SubmitButton>Apply</form.SubmitButton>
-      </form.AppForm>
+      <form.SubmitButton>Apply</form.SubmitButton>
     </StyledForm>
   );
 }

--- a/stories/utils.tsx
+++ b/stories/utils.tsx
@@ -11,6 +11,8 @@ export const AccordionDecorator: Decorator = (Story) => (
 
 const excludeDecorator = new Set([
   'forms-form-tanstack-generalsettings--general-settings',
+  'forms-form-tanstack-appform--simple-app-form',
+  'forms-form-tanstack-appform--meta-app-form',
 ]);
 
 export const RootLayoutDecorator: Decorator = (Story, ctx) => {


### PR DESCRIPTION
for unified and simplified form declaration.

It deprecate `Form` (with migration instructions).

Closes: https://github.com/zakodium-oss/react-science/issues/1012

docs: add stories for AppForm

* show regular use case
* show use-case with meta submit