### PR TITLE
fix: `<AppForm form>` prop binding

### DIFF
--- a/src/components/form/components/layout/form.tsx
+++ b/src/components/form/components/layout/form.tsx
@@ -1,4 +1,4 @@
-import type { SyntheticEvent } from 'react';
+import type { ReactNode, SyntheticEvent } from 'react';
 
 import { withForm } from '../../context/use_ts_form.js';
 import type { FormProps as DomFormProps } from '../input_groups/form.js';
@@ -27,34 +27,57 @@ const defaultValues: any = undefined;
  * Mount `form.AppForm` and `Form` with default onSubmit.
  * It reduces the boilerplate code.
  */
-export const AppForm = withForm({
-  defaultValues,
-  props,
-  render: function FormRender(props) {
-    const { form, children, domValidate, onSubmitMeta, ...domProps } = props;
-    const { AppForm } = form;
+export const AppForm = minimalForm(
+  withForm({
+    defaultValues,
+    props,
+    render: function FormRender(props) {
+      const { form, children, domValidate, onSubmitMeta, ...domProps } = props;
+      const { AppForm } = form;
 
-    return (
-      <AppForm>
-        {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-        <DomForm
-          onSubmit={(event) => {
-            event.preventDefault();
+      return (
+        <AppForm>
+          {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+          <DomForm
+            onSubmit={(event) => {
+              event.preventDefault();
 
-            const meta = onSubmitMeta?.(
-              // onSubmit event is not typed properly.
-              // It uses Event instead of SubmitEvent.
-              event as SyntheticEvent<HTMLFormElement, SubmitEvent>,
-            );
+              const meta = onSubmitMeta?.(
+                // onSubmit event is not typed properly.
+                // It uses Event instead of SubmitEvent.
+                event as SyntheticEvent<HTMLFormElement, SubmitEvent>,
+              );
 
-            void form.handleSubmit(meta);
-          }}
-          {...domProps}
-          noValidate={!domValidate}
-        >
-          {children}
-        </DomForm>
-      </AppForm>
-    );
-  },
-});
+              void form.handleSubmit(meta);
+            }}
+            {...domProps}
+            noValidate={!domValidate}
+          >
+            {children}
+          </DomForm>
+        </AppForm>
+      );
+    },
+  }),
+);
+
+type MinimalProps<Props extends { form: unknown }> = Omit<Props, 'form'> & {
+  /**
+   * Some properties of form are ignored because it is known to produce type errors on usage.
+   */
+  form: Omit<
+    Props['form'],
+    // field array API cause this kind of errors:
+    // Types of property 'pushFieldValue' are incompatible.
+    //  ...
+    //    Type 'any' is not assignable to type 'never'.
+    'pushFieldValue' | 'insertFieldValue' | 'replaceFieldValue'
+  >;
+};
+type MinimalFunctionComponent<Props> = (props: Props) => ReactNode;
+
+function minimalForm<Props extends { form: unknown }>(
+  component: MinimalFunctionComponent<Props>,
+): MinimalFunctionComponent<MinimalProps<Props>> {
+  return component as MinimalFunctionComponent<MinimalProps<Props>>;
+}

--- a/stories/components/form/tanstack/app-form.stories.tsx
+++ b/stories/components/form/tanstack/app-form.stories.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import type { Meta } from '@storybook/react-vite';
+import { revalidateLogic } from '@tanstack/react-form';
 import { action } from 'storybook/actions';
 import { z } from 'zod';
 
@@ -26,17 +27,21 @@ const schema = z.object({
   // coerce number must be annotated, otherwise tanstack form inference will throw error
   // due to `age: unknown` in defaultValues
   age: z.coerce.number<string>().min(18),
+  // ensure no errors in types with `<AppForm form` when schema contains z.array type.
+  table: z.array(z.object({ id: z.string() })),
 });
 
 const defaultValues: z.input<typeof schema> = {
   name: '',
   age: '',
+  table: [],
 };
 
 export function SimpleAppForm(props: Pick<AppFormProps, 'layout'>) {
   const form = useForm({
     defaultValues,
     validators: { onDynamic: schema, onSubmit: schema },
+    validationLogic: revalidateLogic({ mode: 'change' }),
     onSubmit: ({ value }) => {
       const parsedValue = schema.parse(value);
       action('onSubmit')(parsedValue);


### PR DESCRIPTION
Ignore tanstack form api related to arrays.
It solves this kind of error due to `z.array()` validators and tanstack form inference:

```
Error: src/component/modal/setting/tanstack_general_settings/general_settings.tsx(101,7): error TS2322: Type 'AppFieldExtendedReactFormApi<{ display: { general?: { experimentalFeatures?: { display: boolean; visible: boolean; open?: boolean | undefined; } | undefined; hidePanelsBar?: boolean | undefined; } | undefined; panels?: { ...; } | undefined; toolBarButtons?: { ...; } | undefined; }; ... 11 more ...; axis?: { ...; } |...' is not assignable to type 'AppFieldExtendedReactFormApi<any, any, any, FormAsyncValidateOrFn<any> | undefined, any, FormAsyncValidateOrFn<any> | undefined, any, FormAsyncValidateOrFn<any> | undefined, ... 5 more ..., { ...; }>'.
  Types of property 'pushFieldValue' are incompatible.
    Type '<TField extends "nuclei" | "externalAPIs" | "databases.data" | "infoBlock.fields" | "spectraColors.oneDimension" | "spectraColors.twoDimensions" | "spectraLabel.fields">(field: TField, value: (TField extends "display" | ... 223 more ... | `spectraLabel.fields[${number}].uuid` ? DeepRecord<...>[TField] : never) exten...' is not assignable to type '<TField extends never>(field: TField, value: any, options?: UpdateMetaOptions | undefined) => void'.
      Types of parameters 'value' and 'value' are incompatible.
        Type 'any' is not assignable to type 'never'.
```

Refs: https://github.com/cheminfo/nmrium/actions/runs/28363594700/job/84024046363?pr=4230