### PR TITLE
feat: `Select` support number value

### DIFF
--- a/src/components/form/components/input/index.ts
+++ b/src/components/form/components/input/index.ts
@@ -1,9 +1,13 @@
-export { type Checkbox as _Checkbox } from './checkbox.js';
-export { type ColorPicker as _ColorPicker } from './color_picker.js';
-export { type Input as _Input } from './input.js';
-export { type NumericInput as _NumericInput } from './numeric_input.js';
-export { type RadioGroup as _RadioGroup } from './radio_group.js';
-export { type ResetButton as _ResetButton } from './reset_button.js';
-export { type Select as _Select } from './select.js';
-export { type SubmitButton as _SubmitButton } from './submit_button.js';
-export { type Switch as _Switch } from './switch.js';
+export type { Checkbox as _Checkbox } from './checkbox.js';
+export type { ColorPicker as _ColorPicker } from './color_picker.js';
+export type { Input as _Input } from './input.js';
+export type { NumericInput as _NumericInput } from './numeric_input.js';
+export type { RadioGroup as _RadioGroup } from './radio_group.js';
+export type { ResetButton as _ResetButton } from './reset_button.js';
+export type {
+  Select as _Select,
+  SelectOptionType,
+  SelectProps,
+} from './select.js';
+export type { SubmitButton as _SubmitButton } from './submit_button.js';
+export type { Switch as _Switch } from './switch.js';

--- a/src/components/form/components/input/select.tsx
+++ b/src/components/form/components/input/select.tsx
@@ -2,22 +2,42 @@ import { useFieldContext } from '../../context/use_ts_form.js';
 import { getIntent } from '../../utils/use_intent.js';
 import type { FormGroupInputProps } from '../input_groups/form_group.js';
 import { FormGroup } from '../input_groups/form_group.js';
+import type { RealSelectProps } from '../input_groups/select.js';
 import { Select as SelectInput } from '../input_groups/select.js';
 import type { SelectId } from '../util/select.js';
 
-interface SelectOptionType {
+export interface SelectOptionType {
   label: string;
-  value: string;
+  value: SelectId;
 }
 
-interface SelectProps extends Omit<FormGroupInputProps, 'placeholder'> {
+/**
+ * Props for `form.Select` component
+ */
+export interface SelectProps
+  extends
+    Omit<FormGroupInputProps, 'placeholder'>,
+    Pick<
+      RealSelectProps<SelectOptionType, SelectId>,
+      'disabled' | 'filterable' | 'renderButton'
+    > {
   items: SelectOptionType[];
 }
 
 export function Select(props: SelectProps) {
-  const { label, items, required, helpText, layout, fullWidth } = props;
+  const {
+    label,
+    items,
+    required,
+    helpText,
+    layout,
+    fullWidth,
+    disabled,
+    filterable,
+    renderButton,
+  } = props;
 
-  const field = useFieldContext<SelectId>();
+  const field = useFieldContext<SelectId | undefined>();
   const error = field
     .getMeta()
     .errors.map((e) => e.message)
@@ -26,7 +46,6 @@ export function Select(props: SelectProps) {
   const intent = getIntent(error);
 
   function onItemSelect(selected: SelectId | undefined) {
-    if (!selected) return;
     return field.handleChange(selected);
   }
 
@@ -48,6 +67,9 @@ export function Select(props: SelectProps) {
         onChange={onItemSelect}
         intent={intent}
         name={field.name}
+        disabled={disabled}
+        filterable={filterable}
+        renderButton={renderButton}
       />
     </FormGroup>
   );

--- a/src/components/form/components/input_groups/select.tsx
+++ b/src/components/form/components/input_groups/select.tsx
@@ -89,7 +89,7 @@ export type SelectProps<OptionType, ID extends SelectId> = FieldGroupProps &
  * @constructor
  */
 
-interface RealSelectProps<OptionType, ID extends SelectId> extends Pick<
+export interface RealSelectProps<OptionType, ID extends SelectId> extends Pick<
   BPSelectProps<OptionType>,
   'filterable' | 'items'
 > {


### PR DESCRIPTION
* `onChange` with falsy `selected` is now properly forwarded
* `SelectOptionType` value is now `SelectId`
* `SelectOptionType` is exported
* `SelectProps` includes `disabled`, `filterable` and `renderButton` props from blueprintjs Select
* `SelectProps` is exported

Closes: https://github.com/zakodium-oss/react-science/issues/1019