### PR TITLE
fix(toolbar): add hover delays to toolbar tooltips

### DIFF
--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -310,6 +310,8 @@ function ToolbarItemInternal(props: ToolbarItemInternalProps) {
               placement: vertical ? 'right' : 'bottom',
               intent,
               compact: true,
+              hoverCloseDelay: 300,
+              hoverOpenDelay: 300,
               interactionKind: 'hover',
               ...tooltipProps,
             }


### PR DESCRIPTION
Use a 300 ms delay for closing so that the user has time to move to the contents. This is especially useful for tooltips with help content. Adjust the open delay as well so two tooltips cannot be open at the same time.

Refs: https://github.com/cheminfo/nmrium/issues/4245