### PR TITLE
fix: adjust icon margin when render aside a tag

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -42,25 +42,27 @@ const ButtonTag = styled(Tag)`
 
 interface InnerButtonProps {
   isIconButton: boolean;
+  isTagButton: boolean;
 }
 
 /*
   Setting the line-height makes sure that when passing regular text in icons instead of an svg, they are vertically centered
   max-width makes sure buttons with tag or hoverability indicator (both implying absolutely positioned elements) keep their intended width
-  When a button just has an icon, we override BP styles and remove the margin-right, because if it also has tag prop this is required to keep the layout correct.
+  When a button just has an icon with a tag, we override BP styles and remove the margin-right to keep the layout correct.
 */
-const buttonStyles = ({ isIconButton }: InnerButtonProps) => `
+const buttonStyles = ({ isIconButton, isTagButton }: InnerButtonProps) => `
   line-height: 1em;
   position: relative;
   max-width: ${isIconButton ? '30px' : 'none'};
 
   & .${Classes.ICON} {
-    ${isIconButton ? 'margin-right: 0px;' : ''}
+    ${isIconButton && isTagButton ? 'margin-right: 0px;' : ''}
   }
 `;
 
+const propsToIgnore = new Set(['isIconButton', 'isTagButton']);
 function shouldForwardButtonProp(propName: string) {
-  return propName !== 'isIconButton';
+  return !propsToIgnore.has(propName);
 }
 
 const TooltipAnchorButton = styled(AnchorButton, {
@@ -99,6 +101,7 @@ export function Button(props: ButtonProps) {
           {...targetProps}
           {...buttonProps}
           isIconButton={!children && !buttonProps.text}
+          isTagButton={Boolean(tag)}
         >
           {tag && (
             <ButtonTag round intent="success" {...tagProps}>

--- a/src/pages/demo/App.tsx
+++ b/src/pages/demo/App.tsx
@@ -8,10 +8,6 @@ import { FifoLoggerProvider, RootLayout } from '../../components/index.js';
 import MainLayout from './MainLayout.js';
 import { queryClient } from './query_client.js';
 
-import '@blueprintjs/core/lib/css/blueprint.css';
-import '@blueprintjs/select/lib/css/blueprint-select.css';
-import '@blueprintjs/icons/lib/css/blueprint-icons.css';
-
 const fifoLogger = new FifoLogger({ level: 'debug' });
 
 export default function App() {

--- a/src/pages/demo/MainLayout.tsx
+++ b/src/pages/demo/MainLayout.tsx
@@ -1,7 +1,8 @@
 import { Spinner } from '@blueprintjs/core';
 import type { FallbackProps } from 'react-error-boundary';
 import { ErrorBoundary } from 'react-error-boundary';
-import { FaBook, FaMeteor } from 'react-icons/fa';
+import { FaBook, FaExpand, FaMeteor } from 'react-icons/fa';
+import { TbZoom } from 'react-icons/tb';
 import { useKbsGlobal } from 'react-kbs';
 
 import {
@@ -26,6 +27,7 @@ import {
   Header,
   SplitPane,
   Toolbar,
+  TooltipHelpContent,
 } from '../../components/index.js';
 
 import { loadFiles } from './helpers/loadFiles.js';
@@ -105,11 +107,44 @@ export default function MainLayout() {
           <FullscreenToolbarButton />
         </Toolbar>
       </Header>
-      <div
-        style={{
-          flex: 1,
-        }}
-      >
+      <div style={{ flex: 1, display: 'flex' }}>
+        <Toolbar vertical>
+          <Toolbar.Item
+            tooltip={
+              <TooltipHelpContent
+                title="Zoom in / out"
+                shortcuts={['Esc']}
+                subTitles={[
+                  { title: 'Vertical', shortcuts: ['Scroll wheel'] },
+                  { title: 'Horizontal', shortcuts: ['⇧', 'Scroll wheel'] },
+                  {
+                    title: 'Horizontal and Vertical',
+                    shortcuts: ['CTRL', 'drag'],
+                  },
+                  { title: 'Pan', shortcuts: ['Right button'] },
+                ]}
+                style={{ minWidth: '300px' }}
+              />
+            }
+            icon={<TbZoom strokeWidth={3} />}
+          />
+          <Toolbar.Item
+            tooltip={
+              <TooltipHelpContent
+                title="Zoom out"
+                subTitles={[
+                  { title: 'Horizontal', shortcuts: ['f'] },
+                  { title: 'Horizontal and Vertical', shortcuts: ['f', 'f'] },
+                ]}
+                description={`Zoom out by double-clicking the left mouse button, and fully zoom out horizontally by pressing the key "f". Alternatively, press the key "ff" to fit the spectra horizontally and vertically.`}
+                link="https://docs.nmrium.org/help/zoom-and-scale"
+              />
+            }
+            icon={<FaExpand />}
+          />
+          <Toolbar.Item tooltip="Test tag" icon="align-center" tag="1" />
+        </Toolbar>
+
         <SplitPane
           defaultSize="400px"
           closeThreshold={500}

--- a/src/pages/demo/main.css
+++ b/src/pages/demo/main.css
@@ -1,3 +1,10 @@
+@layer react-science, blueprint;
+
+@import url('../../../styles/preflight.css') layer(react-science);
+@import url('@blueprintjs/core') layer(blueprint);
+@import url('@blueprintjs/icons') layer(blueprint);
+@import url('@blueprintjs/select') layer(blueprint);
+
 html,
 body,
 #root {

--- a/src/pages/demo/main.tsx
+++ b/src/pages/demo/main.tsx
@@ -4,7 +4,6 @@ import { createRoot } from 'react-dom/client';
 import App from './App.js';
 
 import './main.css';
-import '../../../styles/preflight.css';
 
 createRoot(document.querySelector('#root') as HTMLDivElement).render(
   <StrictMode>

--- a/tests/app/toolbar.test.ts
+++ b/tests/app/toolbar.test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('toolbar', async ({ page }) => {
   await page.goto('http://localhost:5173/pages/demo.html');
-  await expect(page.getByRole('toolbar').getByRole('button')).toHaveCount(6);
+  await expect(page.getByRole('toolbar').getByRole('button')).toHaveCount(9);
 });


### PR DESCRIPTION
before it was always adjusted.
But there is weird edge case the `margin-right: 0px;` is ignored because blueprint uses higher specificity. It is un-noticable on stories.

In some app, we use css `@layer` to import react-science and blueprint css stylesheets. In this case `margin-right: 0px;` always apply and breaks all icons alignment (because no-layer wins over layer).