### PR TITLE
feat: export data types from react-table

### DIFF
--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -30,3 +30,8 @@ declare module '@tanstack/react-table' {
   }
   /* eslint-enable @typescript-eslint/no-unused-vars */
 }
+
+export type {
+  CellData as TableCellData,
+  RowData as TableRowData,
+} from '@tanstack/react-table';


### PR DESCRIPTION
Allows end users to get them even if they still depend on react-table v8.
